### PR TITLE
Header propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ All requests and responses use JSON-RPC 2.0. Tool input schemas are described us
 - Add a description and annotations for metadata and hints.
 - Specify the input type (must have a Circe `Codec` and Tapir `Schema`).
 - Provide the server logic as a function from input to `Either[String, String]` (or a generic effect type).
+  - Use `handle` to connect the tool definition with the server logic when the use of headers is not required.
+  - Use `handleWithHeaders` to connect the tool definition with the server logic when headers are required.
 - Create a Tapir endpoint by providing your tools to `mcpEndpoint` 
 - Start an HTTP server using your preferred Tapir server interpreter.
 

--- a/core/src/main/scala/chimp/McpHandler.scala
+++ b/core/src/main/scala/chimp/McpHandler.scala
@@ -67,7 +67,7 @@ class McpHandler[F[_]](tools: List[ServerTool[?, F]], name: String = "Chimp MCP 
         toolsByName.get(toolName) match
           case Some(tool) =>
             // Use Circe's Decoder for argument decoding
-            def inputSnippet = args.noSpaces.take(200)
+            def inputSnippet = args.noSpaces.take(200) // for error reporting
             tool.inputDecoder.decodeJson(args) match
               case Right(decodedInput) => handleDecodedInput(tool, decodedInput, id, headers)
               case Left(decodingError) =>

--- a/core/src/main/scala/chimp/McpHandler.scala
+++ b/core/src/main/scala/chimp/McpHandler.scala
@@ -5,10 +5,10 @@ import io.circe.*
 import io.circe.syntax.*
 import org.slf4j.LoggerFactory
 import sttp.apispec.circe.*
-import sttp.tapir.*
-import sttp.tapir.docs.apispec.schema.TapirSchemaToJsonSchema
 import sttp.monad.MonadError
 import sttp.monad.syntax.*
+import sttp.tapir.*
+import sttp.tapir.docs.apispec.schema.TapirSchemaToJsonSchema
 
 /** The MCP server handles JSON-RPC requests for tool listing, invocation, and initialization.
   *
@@ -55,7 +55,9 @@ class McpHandler[F[_]](tools: List[ServerTool[?, F]], name: String = "Chimp MCP 
   /** Handles the 'tools/call' JSON-RPC method. Attempts to decode the tool name and arguments, then dispatches to the tool logic. Provides
     * detailed error messages for decode failures.
     */
-  private def handleToolsCall(params: Option[io.circe.Json], id: RequestId, headerValue: Option[String])(using MonadError[F]): F[JSONRPCMessage] =
+  private def handleToolsCall(params: Option[io.circe.Json], id: RequestId, headerValue: Option[String])(using
+      MonadError[F]
+  ): F[JSONRPCMessage] =
     val toolNameOpt = params.flatMap(_.hcursor.downField("name").as[String].toOption)
     val argumentsOpt = params.flatMap(_.hcursor.downField("arguments").focus)
     (toolNameOpt, argumentsOpt) match
@@ -78,7 +80,9 @@ class McpHandler[F[_]](tools: List[ServerTool[?, F]], name: String = "Chimp MCP 
         protocolError(id, JSONRPCErrorCodes.InvalidParams.code, "Missing tool name").unit
 
   /** Handles a successfully decoded tool input, dispatching to the tool's logic. */
-  private def handleDecodedInput[T](tool: ServerTool[T, F], decodedInput: T, id: RequestId, headerValue: Option[String])(using MonadError[F]): F[JSONRPCMessage] =
+  private def handleDecodedInput[T](tool: ServerTool[T, F], decodedInput: T, id: RequestId, headerValue: Option[String])(using
+      MonadError[F]
+  ): F[JSONRPCMessage] =
     tool
       .logic(decodedInput, headerValue)
       .map:

--- a/core/src/main/scala/chimp/McpHandler.scala
+++ b/core/src/main/scala/chimp/McpHandler.scala
@@ -134,6 +134,7 @@ class McpHandler[F[_]](tools: List[ServerTool[?, F]], name: String = "Chimp MCP 
           }
           JSONRPCMessage.BatchResponse(filtered)
         }
+      case Right(notification: JSONRPCMessage.Notification) => notification.unit
       case Right(_) => protocolError(RequestId("null"), JSONRPCErrorCodes.InvalidRequest.code, "Invalid request type").unit
     responseF.map: response =>
       val responseJson = response.asJson

--- a/core/src/main/scala/chimp/McpHandler.scala
+++ b/core/src/main/scala/chimp/McpHandler.scala
@@ -55,18 +55,16 @@ class McpHandler[F[_]](tools: List[ServerTool[?, F]], name: String = "Chimp MCP 
   /** Handles the 'tools/call' JSON-RPC method. Attempts to decode the tool name and arguments, then dispatches to the tool logic. Provides
     * detailed error messages for decode failures.
     */
-  private def handleToolsCall(params: Option[io.circe.Json], id: RequestId)(using MonadError[F]): F[JSONRPCMessage] =
-    // Extract tool name and arguments in a functional, idiomatic way
+  private def handleToolsCall(params: Option[io.circe.Json], id: RequestId, headerValue: Option[String])(using MonadError[F]): F[JSONRPCMessage] =
     val toolNameOpt = params.flatMap(_.hcursor.downField("name").as[String].toOption)
     val argumentsOpt = params.flatMap(_.hcursor.downField("arguments").focus)
     (toolNameOpt, argumentsOpt) match
       case (Some(toolName), Some(args)) =>
         toolsByName.get(toolName) match
           case Some(tool) =>
-            def inputSnippet = args.noSpaces.take(200) // for error reporting
-            // Use Circe's Decoder for argument decoding
+            def inputSnippet = args.noSpaces.take(200)
             tool.inputDecoder.decodeJson(args) match
-              case Right(decodedInput) => handleDecodedInput(tool, decodedInput, id)
+              case Right(decodedInput) => handleDecodedInput(tool, decodedInput, id, headerValue)
               case Left(decodingError) =>
                 protocolError(
                   id,
@@ -80,9 +78,9 @@ class McpHandler[F[_]](tools: List[ServerTool[?, F]], name: String = "Chimp MCP 
         protocolError(id, JSONRPCErrorCodes.InvalidParams.code, "Missing tool name").unit
 
   /** Handles a successfully decoded tool input, dispatching to the tool's logic. */
-  private def handleDecodedInput[T](tool: ServerTool[T, F], decodedInput: T, id: RequestId)(using MonadError[F]): F[JSONRPCMessage] =
+  private def handleDecodedInput[T](tool: ServerTool[T, F], decodedInput: T, id: RequestId, headerValue: Option[String])(using MonadError[F]): F[JSONRPCMessage] =
     tool
-      .logic(decodedInput)
+      .logic(decodedInput, headerValue)
       .map:
         case Right(result) =>
           val callResult = ToolCallResult(
@@ -97,28 +95,26 @@ class McpHandler[F[_]](tools: List[ServerTool[?, F]], name: String = "Chimp MCP 
           )
           JSONRPCMessage.Response(id = id, result = callResult.asJson)
 
-  /** Handles a JSON-RPC request, dispatching to the appropriate handler. Logs requests and responses. */
-  def handleJsonRpc(request: Json)(using MonadError[F]): F[Json] =
+  def handleJsonRpc(request: Json, headerValue: Option[String])(using MonadError[F]): F[Json] =
     logger.debug(s"Request: $request")
     val responseF: F[JSONRPCMessage] = request.as[JSONRPCMessage] match
       case Left(err) => protocolError(RequestId("null"), JSONRPCErrorCodes.ParseError.code, s"Parse error: ${err.message}").unit
       case Right(JSONRPCMessage.Request(_, method, params: Option[io.circe.Json], id)) =>
         method match
           case "tools/list" => handleToolsList(id).unit
-          case "tools/call" => handleToolsCall(params, id)
+          case "tools/call" => handleToolsCall(params, id, headerValue)
           case "initialize" => handleInitialize(id).unit
           case other        => protocolError(id, JSONRPCErrorCodes.MethodNotFound.code, s"Unknown method: $other").unit
       case Right(JSONRPCMessage.BatchRequest(requests)) =>
-        // For each sub-request, process as a single request using flatMap/fold (no .sequence)
         def processBatch(reqs: List[JSONRPCMessage], acc: List[JSONRPCMessage]): F[List[JSONRPCMessage]] =
           reqs match
             case Nil => acc.reverse.unit
             case head :: tail =>
               head match
                 case JSONRPCMessage.Notification(_, _, _) =>
-                  processBatch(tail, acc) // skip notifications
+                  processBatch(tail, acc)
                 case _ =>
-                  handleJsonRpc(head.asJson).flatMap { respJson =>
+                  handleJsonRpc(head.asJson, headerValue).flatMap { respJson =>
                     val msg = respJson
                       .as[JSONRPCMessage]
                       .getOrElse(
@@ -127,7 +123,6 @@ class McpHandler[F[_]](tools: List[ServerTool[?, F]], name: String = "Chimp MCP 
                     processBatch(tail, msg :: acc)
                   }
         processBatch(requests, Nil).map { responses =>
-          // Per JSON-RPC spec, notifications (no id) should not be included in the response
           val filtered = responses.collect {
             case r @ JSONRPCMessage.Response(_, id, _) => r
             case e @ JSONRPCMessage.Error(_, id, _)    => e

--- a/core/src/main/scala/chimp/McpHandler.scala
+++ b/core/src/main/scala/chimp/McpHandler.scala
@@ -66,8 +66,8 @@ class McpHandler[F[_]](tools: List[ServerTool[?, F]], name: String = "Chimp MCP 
       case (Some(toolName), Some(args)) =>
         toolsByName.get(toolName) match
           case Some(tool) =>
-            // Use Circe's Decoder for argument decoding
             def inputSnippet = args.noSpaces.take(200) // for error reporting
+            // Use Circe's Decoder for argument decoding
             tool.inputDecoder.decodeJson(args) match
               case Right(decodedInput) => handleDecodedInput(tool, decodedInput, id, headers)
               case Left(decodingError) =>

--- a/core/src/main/scala/chimp/mcpEndpoint.scala
+++ b/core/src/main/scala/chimp/mcpEndpoint.scala
@@ -23,7 +23,6 @@ private val logger = LoggerFactory.getLogger(classOf[McpHandler[_]])
   */
 def mcpEndpoint[F[_]](tools: List[ServerTool[?, F]], path: List[String]): ServerEndpoint[Any, F] =
   val mcpHandler = new McpHandler(tools)
-
   val e = infallibleEndpoint.post
     .in(path.foldLeft(emptyInput)((inputSoFar, pathComponent) => inputSoFar / pathComponent))
     .in(extractFromRequest(_.headers))

--- a/core/src/main/scala/chimp/mcpEndpoint.scala
+++ b/core/src/main/scala/chimp/mcpEndpoint.scala
@@ -17,8 +17,6 @@ private val logger = LoggerFactory.getLogger(classOf[McpHandler[_]])
   *   The list of tools to expose.
   * @param path
   *   The path components at which to expose the MCP server.
-  * @param headerName
-  *   The optional name of the header to read. If None, no header is read.
   *
   * @tparam F
   *   The effect type. Might be `Identity` for a endpoints with synchronous logic.
@@ -26,14 +24,14 @@ private val logger = LoggerFactory.getLogger(classOf[McpHandler[_]])
 def mcpEndpoint[F[_]](tools: List[ServerTool[?, F]], path: List[String]): ServerEndpoint[Any, F] =
   val mcpHandler = new McpHandler(tools)
 
-  val base = infallibleEndpoint.post
+  val e = infallibleEndpoint.post
     .in(path.foldLeft(emptyInput)((inputSoFar, pathComponent) => inputSoFar / pathComponent))
     .in(extractFromRequest(_.headers))
     .in(jsonBody[Json])
     .out(jsonBody[Json])
 
   ServerEndpoint.public(
-    base,
+    e,
     me => { (input: (Seq[Header], Json)) =>
       val (headers, json) = input
       given MonadError[F] = me

--- a/core/src/main/scala/chimp/mcpEndpoint.scala
+++ b/core/src/main/scala/chimp/mcpEndpoint.scala
@@ -7,6 +7,7 @@ import sttp.monad.syntax.*
 import sttp.tapir.*
 import sttp.tapir.json.circe.*
 import sttp.tapir.server.ServerEndpoint
+import sttp.model.Header
 
 private val logger = LoggerFactory.getLogger(classOf[McpHandler[_]])
 
@@ -22,34 +23,22 @@ private val logger = LoggerFactory.getLogger(classOf[McpHandler[_]])
   * @tparam F
   *   The effect type. Might be `Identity` for a endpoints with synchronous logic.
   */
-def mcpEndpoint[F[_]](tools: List[ServerTool[?, F]], path: List[String], headerName: Option[String] = None): ServerEndpoint[Any, F] =
+def mcpEndpoint[F[_]](tools: List[ServerTool[?, F]], path: List[String]): ServerEndpoint[Any, F] =
   val mcpHandler = new McpHandler(tools)
+
   val base = infallibleEndpoint.post
     .in(path.foldLeft(emptyInput)((inputSoFar, pathComponent) => inputSoFar / pathComponent))
+    .in(extractFromRequest(_.headers))
     .in(jsonBody[Json])
     .out(jsonBody[Json])
 
-  headerName match {
-    case Some(name) =>
-      val endpoint = base.prependIn(header[Option[String]](name))
-      ServerEndpoint.public(
-        endpoint,
-        me => { (input: (Option[String], Json)) =>
-          val (headerValue, json) = input
-          given MonadError[F] = me
-          mcpHandler
-            .handleJsonRpc(json, headerValue)
-            .map(responseJson => Right(responseJson.deepDropNullValues))
-        }
-      )
-    case None =>
-      ServerEndpoint.public(
-        base,
-        me => { (json: Json) =>
-          given MonadError[F] = me
-          mcpHandler
-            .handleJsonRpc(json, None)
-            .map(responseJson => Right(responseJson.deepDropNullValues))
-        }
-      )
-  }
+  ServerEndpoint.public(
+    base,
+    me => { (input: (Seq[Header], Json)) =>
+      val (headers, json) = input
+      given MonadError[F] = me
+      mcpHandler
+        .handleJsonRpc(json, headers)
+        .map(responseJson => Right(responseJson.deepDropNullValues))
+    }
+  )

--- a/core/src/main/scala/chimp/protocol/model.scala
+++ b/core/src/main/scala/chimp/protocol/model.scala
@@ -2,8 +2,8 @@
 // NOTE: RequestId and ProgressToken use newtype wrappers for spec accuracy and to avoid ambiguous implicits.
 package chimp.protocol
 
+import io.circe.syntax.*
 import io.circe.{Codec, Decoder, Encoder, Json}
-import io.circe.syntax._
 
 // --- JSON-RPC base types ---
 // Use newtype wrappers for union types to avoid ambiguous implicits
@@ -46,8 +46,8 @@ enum JSONRPCMessage:
   case BatchResponse(responses: List[JSONRPCMessage])
 
 object JSONRPCMessage {
-  import io.circe._
-  import io.circe.syntax._
+  import io.circe.*
+  import io.circe.syntax.*
 
   given Decoder[JSONRPCMessage] = Decoder.instance { c =>
     val jsonrpc = c.downField("jsonrpc").as[String].getOrElse("2.0")

--- a/core/src/main/scala/chimp/tool.scala
+++ b/core/src/main/scala/chimp/tool.scala
@@ -48,12 +48,11 @@ case class Tool[I](
     *
     * Same as [[serverLogic]], but using the identity "effect".
     */
-  def handleWithAuth(logic: (I, Option[String]) => Either[String, String]): ServerTool[I, Identity] =
+  def handleWithHeader(logic: (I, Option[String]) => Either[String, String]): ServerTool[I, Identity] =
     ServerTool(name, description, inputSchema, inputDecoder, annotations, (i, t) => logic(i, t))
 
-  //for backward-compatibility
   def handle(logic: I => Either[String, String]): ServerTool[I, Identity] =
-    handleWithAuth((i, _) => logic(i))
+    handleWithHeader((i, _) => logic(i))
     
 //
 

--- a/core/src/main/scala/chimp/tool.scala
+++ b/core/src/main/scala/chimp/tool.scala
@@ -2,6 +2,7 @@ package chimp
 
 import sttp.tapir.Schema
 import io.circe.Decoder
+import sttp.model.Header
 import sttp.shared.Identity
 
 case class ToolAnnotations(
@@ -40,7 +41,7 @@ case class Tool[I](
   /** Combine the tool description with the server logic, that should be executed when the tool is invoked. The logic, given the input,
     * should return either a tool execution error (`Left`), or a successful textual result (`Right`), using the F-effect.
     */
-  def serverLogic[F[_]](logic: (I, Option[String]) => F[Either[String, String]]): ServerTool[I, F] =
+  def serverLogic[F[_]](logic: (I, Seq[Header]) => F[Either[String, String]]): ServerTool[I, F] =
     ServerTool(name, description, inputSchema, inputDecoder, annotations, logic)
 
   /** Combine the tool description with the server logic, that should be executed when the tool is invoked. The logic, given the input,
@@ -48,11 +49,16 @@ case class Tool[I](
     *
     * Same as [[serverLogic]], but using the identity "effect".
     */
-  def handleWithHeader(logic: (I, Option[String]) => Either[String, String]): ServerTool[I, Identity] =
+  def handleWithHeaders(logic: (I, Seq[Header]) => Either[String, String]): ServerTool[I, Identity] =
     ServerTool(name, description, inputSchema, inputDecoder, annotations, (i, t) => logic(i, t))
 
+  /** Combine the tool description with the server logic, that should be executed when the tool is invoked. The logic, given the input,
+    * should return either a tool execution error (`Left`), or a successful textual result (`Right`).
+    *
+    * Same as [[handleWithHeaders]], but using no headers.
+    */
   def handle(logic: I => Either[String, String]): ServerTool[I, Identity] =
-    handleWithHeader((i, _) => logic(i))
+    handleWithHeaders((i, _) => logic(i))
 
 /** A tool that can be executed by the MCP server. */
 case class ServerTool[I, F[_]](
@@ -61,5 +67,5 @@ case class ServerTool[I, F[_]](
     inputSchema: Schema[I],
     inputDecoder: Decoder[I],
     annotations: Option[ToolAnnotations],
-    logic: (I, Option[String]) => F[Either[String, String]]
+    logic: (I, Seq[Header]) => F[Either[String, String]]
 )

--- a/core/src/main/scala/chimp/tool.scala
+++ b/core/src/main/scala/chimp/tool.scala
@@ -53,8 +53,6 @@ case class Tool[I](
 
   def handle(logic: I => Either[String, String]): ServerTool[I, Identity] =
     handleWithHeader((i, _) => logic(i))
-    
-//
 
 /** A tool that can be executed by the MCP server. */
 case class ServerTool[I, F[_]](

--- a/core/src/test/scala/chimp/McpHandlerSpec.scala
+++ b/core/src/test/scala/chimp/McpHandlerSpec.scala
@@ -1,7 +1,7 @@
 package chimp
 
 import chimp.protocol.*
-import chimp.protocol.JSONRPCMessage.given
+import chimp.protocol.JSONRPCMessage.{Notification, given}
 import io.circe.*
 import io.circe.parser.*
 import io.circe.syntax.*
@@ -109,6 +109,18 @@ class McpHandlerSpec extends AnyFlatSpec with Matchers:
         resultObj.isError shouldBe false
         resultObj.content.head shouldBe ToolContent.Text("text", "5")
       case _ => fail("Expected Response")
+
+  it should "accept notifications" in:
+    // Given
+    val req: JSONRPCMessage = Notification(method = "notifications/initialized")
+    val json = req.asJson
+    // When
+    val respJson = handler.handleJsonRpc(json)
+    val resp = respJson.as[JSONRPCMessage].getOrElse(fail("Failed to decode response"))
+    // Then
+    resp match
+      case Notification(_, methodName, _) => methodName shouldBe "notifications/initialized"
+      case _                              => fail("Expected Notification")
 
   it should "return an error for unknown tool" in:
     // Given

--- a/core/src/test/scala/chimp/McpHandlerSpec.scala
+++ b/core/src/test/scala/chimp/McpHandlerSpec.scala
@@ -41,7 +41,7 @@ class McpHandlerSpec extends AnyFlatSpec with Matchers:
   val headerEchoTool = tool("headerEcho")
     .description("Echoes the header value if present.")
     .input[HeaderEchoInput]
-    .handleWithAuth { (in, headerValueOpt) =>
+    .handleWithHeader { (in, headerValueOpt) =>
       headerValueOpt match {
         case Some(headerValue) => Right(s"header value: $headerValue")
         case None        => Right("no header")

--- a/examples/src/main/scala/chimp/adderWithAuthMcp.scala
+++ b/examples/src/main/scala/chimp/adderWithAuthMcp.scala
@@ -7,7 +7,6 @@ package chimp
 import sttp.tapir.*
 import sttp.tapir.server.netty.sync.NettySyncServer
 
-
 @main def mcpAuthApp(): Unit =
   val adderTool = tool("adder")
     .description("Adds two numbers")

--- a/examples/src/main/scala/chimp/adderWithAuthMcp.scala
+++ b/examples/src/main/scala/chimp/adderWithAuthMcp.scala
@@ -1,0 +1,28 @@
+package chimp
+
+//> using dep com.softwaremill.chimp::core:0.1.2
+//> using dep com.softwaremill.sttp.tapir::tapir-netty-server-sync:1.11.33
+//> using dep ch.qos.logback::logback-classic:1.5.18
+
+import sttp.tapir.*
+import sttp.tapir.server.netty.sync.NettySyncServer
+
+
+@main def mcpAuthApp(): Unit =
+  val adderTool = tool("adder")
+    .description("Adds two numbers")
+    .withAnnotations(ToolAnnotations(idempotentHint = Some(true)))
+    .input[Input]
+
+  def logic(i: Input, headerValue: Option[String]): Either[String, String] =
+    val tokenMsg = headerValue.map(t => s"token: $t").getOrElse("no token provided")
+    Right(s"The result is ${i.a + i.b} ($tokenMsg)")
+
+  val adderServerTool = adderTool.handleWithHeader(logic)
+
+  val mcpServerEndpoint = mcpEndpoint(List(adderServerTool), List("mcp"), Some("test_header_1"))
+
+  NettySyncServer()
+    .port(8080)
+    .addEndpoint(mcpServerEndpoint)
+    .startAndWait()


### PR DESCRIPTION
Hello!

I'm writing an MCP server which has a requirement to do an auth check on each tool call.
The recommended way to implement this is by letting the MCP client handle obtaining the token, and passing the token from the MCP client to the MCP server through the header.

I have implemented a proposed solution to provide support in chimp for this. There are two main changes in my suggestion:
1. The `mcpEndpoint` method takes an optional name of the header (defaulted to no header).
2. A `handleWithHeader` method is added in which the logic takes in the value of the header as a parameter.

I included unit tests for my changed and added an example on how it can be used.

I also recorded a video to show it working, I'll attach it to the PR.

https://github.com/user-attachments/assets/f27ca201-2979-489c-9cf3-cb25bfa916b4

Thanks a lot for considering this PR!