### PR TITLE
Show/remove $schema

### DIFF
--- a/core/src/main/scala/chimp/mcpEndpoint.scala
+++ b/core/src/main/scala/chimp/mcpEndpoint.scala
@@ -21,8 +21,14 @@ private val logger = LoggerFactory.getLogger(classOf[McpHandler[_]])
   * @tparam F
   *   The effect type. Might be `Identity` for a endpoints with synchronous logic.
   */
-def mcpEndpoint[F[_]](tools: List[ServerTool[?, F]], path: List[String]): ServerEndpoint[Any, F] =
-  val mcpHandler = new McpHandler(tools)
+def mcpEndpoint[F[_]](
+    tools: List[ServerTool[?, F]],
+    path: List[String],
+    name: String = "Chimp MCP server",
+    version: String = "1.0.0",
+    showJsonSchemaMetadata: Boolean = true
+): ServerEndpoint[Any, F] =
+  val mcpHandler = new McpHandler(tools, name, version, showJsonSchemaMetadata)
   val e = infallibleEndpoint.post
     .in(path.foldLeft(emptyInput)((inputSoFar, pathComponent) => inputSoFar / pathComponent))
     .in(extractFromRequest(_.headers))


### PR DESCRIPTION
Some agents don't like the metadata that Tapir's JSON Schema module generates and prevents tools from being added to AI agents like Augment Code. This change provides the ability to conditionally remove the $schema field which causes an issue.

We also allow you to customize the name and version of the MCP endpoints 

Closes https://github.com/softwaremill/chimp/issues/23