### PR TITLE
Add basic scaladoc for MCP client

### DIFF
--- a/client-streaming/client-zio/src/main/scala/chimp/client/transport/zio/ZioStreamingHttpTransport.scala
+++ b/client-streaming/client-zio/src/main/scala/chimp/client/transport/zio/ZioStreamingHttpTransport.scala
@@ -258,7 +258,6 @@ final class ZioStreamingHttpTransport private (
     )
 
 object ZioStreamingHttpTransport:
-  import scala.concurrent.duration.DurationInt
 
   val defaultReconnectSchedule: Schedule[Any, Any, Any] =
     Schedule.exponential(Duration.fromMillis(100)).jittered || Schedule.spaced(Duration.fromSeconds(30))
@@ -267,7 +266,7 @@ object ZioStreamingHttpTransport:
       backend: StreamBackend[Task, ZioStreams],
       uri: Uri,
       protocolVersion: ProtocolVersion = ProtocolVersion.Latest,
-      timeout: FiniteDuration = 60.seconds,
+      timeout: FiniteDuration = Transport.defaultTimeout,
       reconnectSchedule: Schedule[Any, Any, Any] = defaultReconnectSchedule
   ): Task[ZioStreamingHttpTransport] =
     for
@@ -299,7 +298,7 @@ object ZioStreamingHttpTransport:
       backend: StreamBackend[Task, ZioStreams],
       uri: Uri,
       protocolVersion: ProtocolVersion = ProtocolVersion.Latest,
-      timeout: FiniteDuration = 60.seconds,
+      timeout: FiniteDuration = Transport.defaultTimeout,
       reconnectSchedule: Schedule[Any, Any, Any] = defaultReconnectSchedule
   ): ZIO[Scope, Throwable, ZioStreamingHttpTransport] =
     ZIO.acquireRelease(apply(backend, uri, protocolVersion, timeout, reconnectSchedule))(_.close().ignore)
@@ -308,7 +307,7 @@ object ZioStreamingHttpTransport:
       backend: StreamBackend[Task, ZioStreams],
       uri: Uri,
       protocolVersion: ProtocolVersion = ProtocolVersion.Latest,
-      timeout: FiniteDuration = 60.seconds,
+      timeout: FiniteDuration = Transport.defaultTimeout,
       reconnectSchedule: Schedule[Any, Any, Any] = defaultReconnectSchedule
   ): ZLayer[Any, Throwable, ZioStreamingHttpTransport] =
     ZLayer.scoped(scoped(backend, uri, protocolVersion, timeout, reconnectSchedule))

--- a/client-streaming/client-zio/src/main/scala/chimp/client/transport/zio/ZioStreamingStdioTransport.scala
+++ b/client-streaming/client-zio/src/main/scala/chimp/client/transport/zio/ZioStreamingStdioTransport.scala
@@ -3,7 +3,6 @@ package chimp.client.transport.zio
 import chimp.client.transport.{StreamingStdioTransport, Transport}
 import chimp.protocol.JSONRPCMessage
 import org.slf4j.LoggerFactory
-import sttp.capabilities.zio.ZioStreams
 import sttp.client4.impl.zio.RIOMonadAsyncError
 import sttp.monad.MonadError
 import zio.process.{Command, Process, ProcessInput}
@@ -24,7 +23,7 @@ final class ZioStreamingStdioTransport private (
     writeQueue: Queue[JSONRPCMessage],
     pending: ZioPendingRequests,
     incomingRef: Ref[JSONRPCMessage => Task[Unit]]
-) extends StreamingStdioTransport[Task, ZioStreams](command, env, workDir):
+) extends StreamingStdioTransport[Task](command, env, workDir):
 
   private val log = LoggerFactory.getLogger(classOf[ZioStreamingStdioTransport])
 

--- a/client-streaming/client-zio/src/main/scala/chimp/client/transport/zio/ZioStreamingStdioTransport.scala
+++ b/client-streaming/client-zio/src/main/scala/chimp/client/transport/zio/ZioStreamingStdioTransport.scala
@@ -69,14 +69,12 @@ final class ZioStreamingStdioTransport private (
       .unit
 
 object ZioStreamingStdioTransport:
-  import scala.concurrent.duration.DurationInt
-  private val defaultTimeout: FiniteDuration = 60.seconds
 
   def apply(
       command: List[String],
       env: Map[String, String] = Map.empty,
       workDir: Option[File] = None,
-      timeout: FiniteDuration = defaultTimeout
+      timeout: FiniteDuration = Transport.defaultTimeout
   ): Task[ZioStreamingStdioTransport] =
     for
       scope <- Scope.make
@@ -101,7 +99,7 @@ object ZioStreamingStdioTransport:
       command: List[String],
       env: Map[String, String] = Map.empty,
       workDir: Option[File] = None,
-      timeout: FiniteDuration = defaultTimeout
+      timeout: FiniteDuration = Transport.defaultTimeout
   ): ZIO[Scope, Throwable, ZioStreamingStdioTransport] =
     ZIO.acquireRelease(apply(command, env, workDir, timeout))(_.close().ignore)
 
@@ -109,6 +107,6 @@ object ZioStreamingStdioTransport:
       command: List[String],
       env: Map[String, String] = Map.empty,
       workDir: Option[File] = None,
-      timeout: FiniteDuration = defaultTimeout
+      timeout: FiniteDuration = Transport.defaultTimeout
   ): ZLayer[Any, Throwable, ZioStreamingStdioTransport] =
     ZLayer.scoped(scoped(command, env, workDir, timeout))

--- a/client-streaming/client-zio/src/main/scala/chimp/client/transport/zio/internal/ZioPendingRequests.scala
+++ b/client-streaming/client-zio/src/main/scala/chimp/client/transport/zio/internal/ZioPendingRequests.scala
@@ -1,38 +1,37 @@
 package chimp.client.transport.zio
 
-import chimp.client.McpTransportException
+import chimp.client.{McpTimeoutException, McpTransportException}
 import chimp.client.internal.PendingRequests
 import chimp.protocol.{JSONRPCMessage, RequestId}
 import zio.{Duration, Promise, Ref, Task, UIO, ZIO}
 
-import java.util.concurrent.TimeoutException
 import scala.concurrent.duration.FiniteDuration
 
 private[zio] final class ZioPendingRequests private (pending: Ref[Map[RequestId, Promise[Throwable, JSONRPCMessage]]])
     extends PendingRequests[Task]:
-  override def register(id: RequestId, timeout: FiniteDuration): Task[() => Task[JSONRPCMessage]] =
+  override def register(requestId: RequestId, timeout: FiniteDuration): Task[() => Task[JSONRPCMessage]] =
     Promise
       .make[Throwable, JSONRPCMessage]
       .flatMap: promise =>
         pending
-          .update(_ + (id -> promise))
+          .update(_ + (requestId -> promise))
           .as: () =>
             promise.await
-              .timeoutFail(new TimeoutException(s"Request $id timed out after $timeout"))(Duration.fromScala(timeout))
-              .onError(_ => pending.update(_ - id))
+              .timeoutFail(new McpTimeoutException(requestId))(Duration.fromScala(timeout))
+              .onError(_ => pending.update(_ - requestId))
 
-  override def complete(id: RequestId, msg: JSONRPCMessage): Task[Boolean] =
+  override def complete(requestId: RequestId, msg: JSONRPCMessage): Task[Boolean] =
     pending
       .modify { pending =>
-        pending.get(id) match
-          case Some(promise) => (Some(promise), pending - id)
+        pending.get(requestId) match
+          case Some(promise) => (Some(promise), pending - requestId)
           case None          => (None, pending)
       }
       .flatMap:
         case Some(promise) => promise.succeed(msg).as(true)
         case None          => ZIO.succeed(false)
 
-  override def isPending(id: RequestId): Task[Boolean] = pending.get.map(_.contains(id))
+  override def isPending(requestId: RequestId): Task[Boolean] = pending.get.map(_.contains(requestId))
 
   override def closeAll(reason: String): Task[Unit] =
     pending

--- a/client-streaming/client-zio/src/test/scala/chimp/client/transport/zio/ZioStdioIntegrationSpec.scala
+++ b/client-streaming/client-zio/src/test/scala/chimp/client/transport/zio/ZioStdioIntegrationSpec.scala
@@ -4,7 +4,9 @@ import chimp.client.integration.StdioIntegrationSpec
 import chimp.client.transport.BidirectionalTransport
 import zio.{Task, ZIO}
 
+import scala.concurrent.duration.FiniteDuration
+
 class ZioStdioIntegrationSpec extends StdioIntegrationSpec[Task] with ZioToFuture:
 
-  override def usingTransport[A](command: List[String])(use: BidirectionalTransport[Task] => Task[A]): Task[A] =
-    ZIO.scoped(ZioStreamingStdioTransport.scoped(command).flatMap(use))
+  override def usingTransport[A](command: List[String], timeout: FiniteDuration)(use: BidirectionalTransport[Task] => Task[A]): Task[A] =
+    ZIO.scoped(ZioStreamingStdioTransport.scoped(command, timeout = timeout).flatMap(use))

--- a/client/src/main/scala/chimp/client/McpClient.scala
+++ b/client/src/main/scala/chimp/client/McpClient.scala
@@ -5,45 +5,159 @@ import chimp.client.transport.{BidirectionalTransport, Transport}
 import chimp.protocol.*
 import io.circe.Json
 
+/** A Model Context Protocol (MCP) client that has completed the initialization handshake with a server.
+  *
+  * Exposes the server's advertised capabilities and identity, and provides methods for sending client-initiated requests and notifications
+  * over the underlying [[chimp.client.transport.Transport]].
+  *
+  * For bidirectional interaction (server-initiated requests, resource subscriptions, notification listeners), use
+  * [[BidirectionalMcpClient]] instead.
+  */
 trait McpClient[F[_]]:
+  /** Sends a `ping` request to the server. */
   def ping(): F[Unit]
+
+  /** Closes the underlying transport and releases any resources held by this client. */
   def close(): F[Unit]
 
+  /** Capabilities advertised by the server during the initialization handshake. */
   def serverCapabilities: ServerCapabilities
+
+  /** Server implementation name and version, received during the initialization handshake. */
   def serverInfo: Implementation
 
+  /** Lists tools exposed by the server.
+    *
+    * @param cursor
+    *   Optional pagination cursor returned by a previous call; by default uses `None` and starts from the beginning.
+    */
   def listTools(cursor: Option[Cursor] = None): F[ListToolsResponse]
+
+  /** Invokes a tool on the server.
+    *
+    * @param name
+    *   The tool's name, as reported by [[listTools]].
+    * @param arguments
+    *   JSON object containing the tool's input, matching its declared input schema.
+    */
   def callTool(name: String, arguments: Json): F[CallToolResult]
 
+  /** Lists prompt templates exposed by the server.
+    *
+    * @param cursor
+    *   Optional pagination cursor returned by a previous call; by default uses `None` and starts from the beginning.
+    */
   def listPrompts(cursor: Option[Cursor] = None): F[ListPromptsResult]
+
+  /** Retrieves a prompt template by name, substituting the given arguments.
+    *
+    * @param name
+    *   The prompt's name, as reported by [[listPrompts]].
+    * @param arguments
+    *   Values for the prompt template's arguments; defaults to empty.
+    */
   def getPrompt(name: String, arguments: Map[String, String] = Map.empty): F[GetPromptResult]
 
+  /** Lists resources exposed by the server.
+    *
+    * @param cursor
+    *   Optional pagination cursor returned by a previous call; by default uses `None` and starts from the beginning.
+    */
   def listResources(cursor: Option[Cursor] = None): F[ListResourcesResult]
+
+  /** Lists resource templates exposed by the server.
+    *
+    * @param cursor
+    *   Optional pagination cursor returned by a previous call; by default uses `None` and starts from the beginning.
+    */
   def listResourceTemplates(cursor: Option[Cursor] = None): F[ListResourceTemplatesResult]
+
+  /** Reads the contents of a resource identified by its URI. */
   def readResource(uri: String): F[ReadResourceResult]
 
+  /** Requests completion suggestions for an argument of a prompt or resource template reference. */
   def complete(ref: CompleteRef, argument: CompleteArgument): F[CompleteResult]
 
+  /** Sets the minimum severity level for log messages the server should forward to this client. */
   def setLoggingLevel(level: LoggingLevel): F[Unit]
 
+  /** Sends a progress notification for a previously issued request that advertised a progress token.
+    *
+    * @param token
+    *   The progress token associated with the in-flight request.
+    * @param progress
+    *   Current progress value; the unit is opaque and chosen by the sender.
+    * @param total
+    *   Optional total value, used by the receiver to compute a percentage.
+    * @param message
+    *   Optional human-readable description of the current step.
+    */
   def sendProgress(token: ProgressToken, progress: Double, total: Option[Double] = None, message: Option[String] = None): F[Unit]
+
+  /** Sends a `cancelled` notification, asking the server to stop processing a previously issued request.
+    *
+    * @param requestId
+    *   Identifier of the request to cancel.
+    * @param reason
+    *   Optional human-readable explanation.
+    */
   def sendCancelled(requestId: RequestId, reason: Option[String] = None): F[Unit]
 
+/** An [[McpClient]] used over a [[chimp.client.transport.BidirectionalTransport]], which additionally supports server-initiated
+  * interactions: subscribing to resource updates, notifying the server about changes to the client's roots, and handling notifications
+  * pushed by the server.
+  */
 trait BidirectionalMcpClient[F[_]] extends McpClient[F]:
+  /** Subscribes to updates for the resource identified by the given URI. The server will emit `resources/updated` notifications, which can
+    * be observed via [[onServerNotification]].
+    */
   def subscribeResource(uri: String): F[Unit]
+
+  /** Cancels a subscription previously created with [[subscribeResource]]. */
   def unsubscribeResource(uri: String): F[Unit]
+
+  /** Notifies the server that the list of roots exposed by this client has changed. */
   def sendRootsListChanged(): F[Unit]
+
+  /** Registers a listener for notifications pushed by the server (e.g. resource updates, tool/prompt list changes, log messages). */
   def onServerNotification(listener: ServerNotificationListener[F]): F[Unit]
 
 object McpClient:
+  /** Creates an [[McpClient]] over the given [[chimp.client.transport.Transport]] and performs the initialization handshake with the
+    * server.
+    *
+    * @param transport
+    *   The transport carrying JSON-RPC messages between client and server.
+    * @param clientInfo
+    *   Implementation name and version advertised to the server during initialization.
+    * @param protocolVersion
+    *   Protocol version proposed during initialization; defaults to the latest version supported by chimp.
+    */
   def apply[F[_]](
       transport: Transport[F],
       clientInfo: Implementation,
-      protocolVersion: ProtocolVersion
+      protocolVersion: ProtocolVersion = ProtocolVersion.Latest
   ): F[McpClient[F]] =
     McpClientImpl.create(transport, clientInfo, protocolVersion)
 
-  def apply[F[_]](
+  /** Creates a [[BidirectionalMcpClient]] over the given [[chimp.client.transport.BidirectionalTransport]] and performs the initialization
+    * handshake. The optional handlers determine which client capabilities (roots, sampling, elicitation) are advertised to the server; only
+    * capabilities backed by a handler are enabled.
+    *
+    * @param transport
+    *   The bidirectional transport carrying JSON-RPC messages in both directions.
+    * @param clientInfo
+    *   Implementation name and version advertised to the server during initialization.
+    * @param rootsHandler
+    *   Optional handler invoked when the server requests the client's roots; enables the `roots` capability when provided.
+    * @param samplingHandler
+    *   Optional handler invoked when the server requests an LLM completion via sampling; enables the `sampling` capability when provided.
+    * @param elicitationHandler
+    *   Optional handler invoked when the server requests user input via elicitation; enables the `elicitation` capability when provided.
+    * @param protocolVersion
+    *   Protocol version proposed during initialization; defaults to the latest version supported by chimp.
+    */
+  def bidirectional[F[_]](
       transport: BidirectionalTransport[F],
       clientInfo: Implementation,
       rootsHandler: Option[() => F[ListRootsResult]] = None,

--- a/client/src/main/scala/chimp/client/McpClient.scala
+++ b/client/src/main/scala/chimp/client/McpClient.scala
@@ -123,8 +123,8 @@ trait BidirectionalMcpClient[F[_]] extends McpClient[F]:
   def onServerNotification(listener: ServerNotificationListener[F]): F[Unit]
 
 object McpClient:
-  /** Creates an [[McpClient]] over the given [[chimp.client.transport.Transport]] and performs the initialization handshake with the
-    * server.
+  /** Creates an unidirectional [[McpClient]] over the given [[chimp.client.transport.Transport]] and performs the initialization handshake
+    * with the server.
     *
     * @param transport
     *   The transport carrying JSON-RPC messages between client and server.

--- a/client/src/main/scala/chimp/client/McpClientException.scala
+++ b/client/src/main/scala/chimp/client/McpClientException.scala
@@ -1,5 +1,7 @@
 package chimp.client
 
+import chimp.protocol.RequestId
+
 class McpTransportException(message: String, cause: Throwable = null) extends RuntimeException(message, cause)
 
 final class McpAuthorizationException(message: String, val statusCode: Int) extends McpTransportException(message)
@@ -8,3 +10,5 @@ final class McpSessionNotFoundException(sessionId: String)
     extends McpTransportException(s"Server reported session-id $sessionId as not found")
 
 final class McpProtocolException(message: String) extends McpTransportException(message)
+
+final class McpTimeoutException(requestId: RequestId) extends RuntimeException(s"Request $requestId timed out")

--- a/client/src/main/scala/chimp/client/internal/PendingRequests.scala
+++ b/client/src/main/scala/chimp/client/internal/PendingRequests.scala
@@ -1,5 +1,6 @@
 package chimp.client.internal
 
+import chimp.client.McpTimeoutException
 import chimp.protocol.{JSONRPCErrorCodes, JSONRPCErrorObject, JSONRPCMessage, RequestId}
 import sttp.shared.Identity
 
@@ -8,35 +9,35 @@ import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{Await, Promise}
 
 trait PendingRequests[F[_]]:
-  def register(id: RequestId, timeout: FiniteDuration): F[() => F[JSONRPCMessage]]
-  def complete(id: RequestId, msg: JSONRPCMessage): F[Boolean]
-  def isPending(id: RequestId): F[Boolean]
+  def register(requestId: RequestId, timeout: FiniteDuration): F[() => F[JSONRPCMessage]]
+  def complete(requestId: RequestId, msg: JSONRPCMessage): F[Boolean]
+  def isPending(requestId: RequestId): F[Boolean]
   def closeAll(reason: String): F[Unit]
 
 private[client] final class SyncPendingRequests extends PendingRequests[Identity]:
   private val pending = ConcurrentHashMap[RequestId, Promise[JSONRPCMessage]]()
 
-  override def register(id: RequestId, timeout: FiniteDuration): () => JSONRPCMessage =
+  override def register(requestId: RequestId, timeout: FiniteDuration): () => JSONRPCMessage =
     val promise = Promise[JSONRPCMessage]()
-    pending.put(id, promise)
+    pending.put(requestId, promise)
     () =>
       try Await.result(promise.future, timeout)
       catch
-        case t: TimeoutException =>
-          pending.computeIfPresent(id, (_, _) => null)
-          throw t
+        case _: TimeoutException =>
+          pending.computeIfPresent(requestId, (_, _) => null)
+          throw new McpTimeoutException(requestId)
 
-  override def complete(id: RequestId, msg: JSONRPCMessage): Boolean =
+  override def complete(requestId: RequestId, msg: JSONRPCMessage): Boolean =
     var completed = false
     pending.computeIfPresent(
-      id,
+      requestId,
       (_, promise) =>
         completed = promise.trySuccess(msg)
         null
     )
     completed
 
-  override def isPending(id: RequestId): Boolean = pending.containsKey(id)
+  override def isPending(requestId: RequestId): Boolean = pending.containsKey(requestId)
 
   override def closeAll(reason: String): Unit =
     val it = pending.entrySet().iterator()

--- a/client/src/main/scala/chimp/client/transport/HttpTransport.scala
+++ b/client/src/main/scala/chimp/client/transport/HttpTransport.scala
@@ -12,6 +12,15 @@ import sttp.monad.syntax.*
 import java.util.concurrent.atomic.AtomicReference
 import scala.util.chaining.*
 
+/** Implementation of unidirectional MCP Streamable HTTP transport that exchanges JSON-RPC messages with an MCP server over HTTP.
+  *
+  * @param backend
+  *   The sttp backend used to send HTTP requests.
+  * @param uri
+  *   The MCP endpoint URI.
+  * @param protocolVersion
+  *   Protocol version advertised via the `MCP-Protocol-Version` header; defaults to the latest version supported by chimp.
+  */
 final class HttpTransport[F[_]](
     backend: Backend[F],
     uri: Uri,

--- a/client/src/main/scala/chimp/client/transport/StdioTransport.scala
+++ b/client/src/main/scala/chimp/client/transport/StdioTransport.scala
@@ -13,6 +13,18 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.jdk.CollectionConverters.*
 
+/** A synchronous implementation of MCP Stdio transport. Launches a local MCP server as a subprocess and exchanges line-delimited JSON-RPC
+  * messages over its standard input and output. Standard error from the subprocess is drained and forwarded to the logger.
+  *
+  * @param command
+  *   The command and arguments used to start the subprocess.
+  * @param env
+  *   Additional environment variables to set for the subprocess.
+  * @param workDir
+  *   Optional working directory for the subprocess.
+  * @param timeout
+  *   Maximum time to wait for a response to each request before raising an [[chimp.client.McpTimeoutException]].
+  */
 final class StdioTransport(
     command: List[String],
     env: Map[String, String] = Map.empty,

--- a/client/src/main/scala/chimp/client/transport/StdioTransport.scala
+++ b/client/src/main/scala/chimp/client/transport/StdioTransport.scala
@@ -10,7 +10,7 @@ import java.io.*
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.duration.FiniteDuration
 import scala.jdk.CollectionConverters.*
 
 /** A synchronous implementation of MCP Stdio transport. Launches a local MCP server as a subprocess and exchanges line-delimited JSON-RPC
@@ -29,7 +29,7 @@ final class StdioTransport(
     command: List[String],
     env: Map[String, String] = Map.empty,
     workDir: Option[File] = None,
-    timeout: FiniteDuration = 60.seconds
+    timeout: FiniteDuration = Transport.defaultTimeout
 ) extends BidirectionalTransport[Identity]:
 
   private val log = LoggerFactory.getLogger(classOf[StdioTransport])

--- a/client/src/main/scala/chimp/client/transport/StreamingHttpTransport.scala
+++ b/client/src/main/scala/chimp/client/transport/StreamingHttpTransport.scala
@@ -4,6 +4,10 @@ import sttp.capabilities.Streams
 import sttp.client4.StreamBackend
 import sttp.model.Uri
 
+/** Abstract base for streaming HTTP transports. The extra type parameter `S` carries the streaming capability evidence required by the sttp
+  * [[sttp.client4.StreamBackend]], which is needed to consume Server-Sent Event responses as an asynchronous stream. Concrete
+  * implementations live in effect-specific modules.
+  */
 abstract class StreamingHttpTransport[F[_], S](
     protected val backend: StreamBackend[F, S],
     protected val uri: Uri,

--- a/client/src/main/scala/chimp/client/transport/StreamingStdioTransport.scala
+++ b/client/src/main/scala/chimp/client/transport/StreamingStdioTransport.scala
@@ -2,11 +2,10 @@ package chimp.client.transport
 
 import java.io.File
 
-/** Abstract base for streaming stdio transports. The extra type parameter `S` carries the streaming capability evidence required by the
-  * concrete implementation's effect (e.g. ZIO, fs2), which is needed to consume the subprocess's stdout as an asynchronous stream. Concrete
+/** Abstract base for streaming stdio transports that should consume the subprocess's stdout as an asynchronous stream. Concrete
   * implementations live in effect-specific modules.
   */
-abstract class StreamingStdioTransport[F[_], S](
+abstract class StreamingStdioTransport[F[_]](
     protected val command: List[String],
     protected val env: Map[String, String] = Map.empty,
     protected val workDir: Option[File] = None

--- a/client/src/main/scala/chimp/client/transport/StreamingStdioTransport.scala
+++ b/client/src/main/scala/chimp/client/transport/StreamingStdioTransport.scala
@@ -2,6 +2,10 @@ package chimp.client.transport
 
 import java.io.File
 
+/** Abstract base for streaming stdio transports. The extra type parameter `S` carries the streaming capability evidence required by the
+  * concrete implementation's effect (e.g. ZIO, fs2), which is needed to consume the subprocess's stdout as an asynchronous stream. Concrete
+  * implementations live in effect-specific modules.
+  */
 abstract class StreamingStdioTransport[F[_], S](
     protected val command: List[String],
     protected val env: Map[String, String] = Map.empty,

--- a/client/src/main/scala/chimp/client/transport/StreamingStdioTransport.scala
+++ b/client/src/main/scala/chimp/client/transport/StreamingStdioTransport.scala
@@ -1,6 +1,7 @@
 package chimp.client.transport
 
 import java.io.File
+import scala.concurrent.duration.FiniteDuration
 
 /** Abstract base for streaming stdio transports that should consume the subprocess's stdout as an asynchronous stream. Concrete
   * implementations live in effect-specific modules.
@@ -8,5 +9,6 @@ import java.io.File
 abstract class StreamingStdioTransport[F[_]](
     protected val command: List[String],
     protected val env: Map[String, String] = Map.empty,
-    protected val workDir: Option[File] = None
+    protected val workDir: Option[File] = None,
+    protected val timeout: FiniteDuration = Transport.defaultTimeout
 ) extends BidirectionalTransport[F]

--- a/client/src/main/scala/chimp/client/transport/Transport.scala
+++ b/client/src/main/scala/chimp/client/transport/Transport.scala
@@ -5,6 +5,8 @@ import io.circe.parser
 import io.circe.syntax.*
 import sttp.monad.MonadError
 
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
 /** A unidirectional MCP transport: the client sends a [[chimp.protocol.JSONRPCMessage]] and optionally receives a response back. For
   * transports that doesn't handle server initiated requests.
   */
@@ -20,6 +22,9 @@ trait BidirectionalTransport[F[_]] extends Transport[F]:
   def onIncoming(handler: JSONRPCMessage => F[Unit]): F[Unit]
 
 object Transport:
+
+  val defaultTimeout: FiniteDuration = 60.seconds
+
   private[client] def encode(msg: JSONRPCMessage): String =
     msg.asJson.deepDropNullValues.noSpaces
 

--- a/client/src/main/scala/chimp/client/transport/Transport.scala
+++ b/client/src/main/scala/chimp/client/transport/Transport.scala
@@ -5,11 +5,17 @@ import io.circe.parser
 import io.circe.syntax.*
 import sttp.monad.MonadError
 
+/** A unidirectional MCP transport: the client sends a [[chimp.protocol.JSONRPCMessage]] and optionally receives a response back. For
+  * transports that doesn't handle server initiated requests.
+  */
 trait Transport[F[_]]:
   given monad: MonadError[F]
   def send(msg: JSONRPCMessage): F[Option[JSONRPCMessage]]
   def close(): F[Unit]
 
+/** A bidirectional MCP transport that, in addition to [[Transport.send]] calls, allows the server to push messages to the client. Incoming
+  * messages are delivered to the registered handler via [[onIncoming]]. Used by [[chimp.client.BidirectionalMcpClient]].
+  */
 trait BidirectionalTransport[F[_]] extends Transport[F]:
   def onIncoming(handler: JSONRPCMessage => F[Unit]): F[Unit]
 

--- a/client/src/test/scala/chimp/client/CapabilityHandlerSpec.scala
+++ b/client/src/test/scala/chimp/client/CapabilityHandlerSpec.scala
@@ -42,7 +42,7 @@ class CapabilityHandlerSpec extends AnyFlatSpec with Matchers:
   it should "respond with MethodNotFound for capabilities the client didn't opt into" in:
     val transport = InMemoryTransport()
     planInitResponse(transport)
-    val _ = McpClient[Identity](transport, clientInfo)
+    val _ = McpClient.bidirectional[Identity](transport, clientInfo)
 
     val request: JSONRPCMessage = JSONRPCMessage.Request(method = "sampling/createMessage", id = RequestId("server-2"))
     transport.simulateIncoming(request)

--- a/client/src/test/scala/chimp/client/CapabilityHandlerSpec.scala
+++ b/client/src/test/scala/chimp/client/CapabilityHandlerSpec.scala
@@ -22,7 +22,7 @@ class CapabilityHandlerSpec extends AnyFlatSpec with Matchers:
   it should "respond to a server-initiated roots/list with the registered handler's result" in:
     val transport = InMemoryTransport()
     planInitResponse(transport)
-    val _ = McpClient[Identity](
+    val _ = McpClient.bidirectional[Identity](
       transport,
       clientInfo,
       rootsHandler = Some(() => ListRootsResult(roots = List(Root(uri = "file:///x", name = Some("x")))))
@@ -54,7 +54,7 @@ class CapabilityHandlerSpec extends AnyFlatSpec with Matchers:
   it should "deliver incoming notifications to registered listeners" in:
     val transport = InMemoryTransport()
     planInitResponse(transport)
-    val client = McpClient[Identity](transport, clientInfo)
+    val client = McpClient.bidirectional[Identity](transport, clientInfo)
     var received: Option[ServerNotification] = None
     val listener: ServerNotificationListener[Identity] = n => { received = Some(n); () }
     val _ = client.onServerNotification(listener)
@@ -68,7 +68,7 @@ class CapabilityHandlerSpec extends AnyFlatSpec with Matchers:
   it should "include opted-in capabilities on initialize" in:
     val transport = InMemoryTransport()
     planInitResponse(transport)
-    val _ = McpClient[Identity](
+    val _ = McpClient.bidirectional[Identity](
       transport,
       clientInfo,
       rootsHandler = Some(() => ListRootsResult(roots = Nil)),

--- a/client/src/test/scala/chimp/client/integration/BidirectionalHttpMcpClientTests.scala
+++ b/client/src/test/scala/chimp/client/integration/BidirectionalHttpMcpClientTests.scala
@@ -1,7 +1,7 @@
 package chimp.client.integration
 
-import chimp.client.BidirectionalMcpClient
 import chimp.client.notifications.{ServerNotification, ServerNotificationListener}
+import chimp.client.{BidirectionalMcpClient, McpTimeoutException}
 import chimp.protocol.*
 import io.circe.Json
 import org.scalatest.Assertion
@@ -9,7 +9,6 @@ import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.monad.syntax.*
 
-import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
 import scala.concurrent.Future
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -86,7 +85,7 @@ trait BidirectionalHttpMcpClientTests[F[_]] extends AsyncFlatSpec with Matchers:
       for _ <- attempt
       yield
         samplingInvoked.get() shouldBe true
-        failure.get().exists(_.isInstanceOf[TimeoutException]) shouldBe true
+        failure.get().exists(_.isInstanceOf[McpTimeoutException]) shouldBe true
 
   private def loggingCounter(counter: AtomicInteger): ServerNotificationListener[F] = notification =>
     notification match

--- a/client/src/test/scala/chimp/client/integration/BidirectionalHttpMcpClientTests.scala
+++ b/client/src/test/scala/chimp/client/integration/BidirectionalHttpMcpClientTests.scala
@@ -1,6 +1,7 @@
 package chimp.client.integration
 
 import chimp.client.notifications.{ServerNotification, ServerNotificationListener}
+import chimp.client.transport.Transport
 import chimp.client.{BidirectionalMcpClient, McpTimeoutException}
 import chimp.protocol.*
 import io.circe.Json
@@ -18,7 +19,7 @@ trait BidirectionalHttpMcpClientTests[F[_]] extends AsyncFlatSpec with Matchers:
 
   protected def withProxiedBidirectionalClient(
       samplingHandler: Option[CreateMessageRequest => F[CreateMessageResult]] = None,
-      timeout: FiniteDuration = 60.seconds
+      timeout: FiniteDuration = Transport.defaultTimeout
   )(test: (MCPProxyContainer, BidirectionalMcpClient[F]) => F[Assertion]): Future[Assertion]
 
   "GET SSE stream" should "resume delivering notifications after the underlying connection is cut" in:

--- a/client/src/test/scala/chimp/client/integration/StdioIntegrationSpec.scala
+++ b/client/src/test/scala/chimp/client/integration/StdioIntegrationSpec.scala
@@ -1,14 +1,16 @@
 package chimp.client.integration
 
-import chimp.client.transport.BidirectionalTransport
-import chimp.client.{BidirectionalMcpClient, McpClient}
+import chimp.client.transport.{BidirectionalTransport, Transport}
+import chimp.client.{BidirectionalMcpClient, McpClient, McpTimeoutException}
 import chimp.protocol.*
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.monad.syntax.*
 
+import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.Future
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 abstract class StdioIntegrationSpec[F[_]]
     extends AsyncFlatSpec
@@ -21,7 +23,7 @@ abstract class StdioIntegrationSpec[F[_]]
   protected val everythingServerCommand: List[String] =
     List("npx", "-y", "@modelcontextprotocol/server-everything@2026.1.26")
 
-  def usingTransport[A](command: List[String])(use: BidirectionalTransport[F] => F[A]): F[A]
+  def usingTransport[A](command: List[String], timeout: FiniteDuration)(use: BidirectionalTransport[F] => F[A]): F[A]
 
   private val clientInfo = Implementation(name = "chimp-integration", version = "0.0.1")
 
@@ -34,9 +36,24 @@ abstract class StdioIntegrationSpec[F[_]]
       elicitationHandler: Option[ElicitRequest => F[ElicitResult]] = None
   )(test: BidirectionalMcpClient[F] => F[Assertion]): Future[Assertion] =
     toFuture(
-      usingTransport(everythingServerCommand): transport =>
+      usingTransport(everythingServerCommand, Transport.defaultTimeout): transport =>
         McpClient
           .bidirectional[F](transport, clientInfo, rootsHandler, samplingHandler, elicitationHandler, ProtocolVersion.Latest)
           .flatMap: client =>
             test(client).flatMap(assertion => client.close().map(_ => assertion))
     )
+
+  "a request" should "fail with McpTimeoutException when the subprocess does not respond within the configured timeout" in:
+    val failure = AtomicReference[Option[Throwable]](None)
+    toFuture(
+      usingTransport(List("sleep", "30"), timeout = 200.millis): transport =>
+        val request: JSONRPCMessage = JSONRPCMessage.Request(method = "ping", params = None, id = RequestId(1))
+        transport
+          .send(request)
+          .map(_ => ())
+          .handleError:
+            case t =>
+              failure.set(Some(t))
+              monad.unit(())
+    ).map: _ =>
+      failure.get().exists(_.isInstanceOf[McpTimeoutException]) shouldBe true

--- a/client/src/test/scala/chimp/client/integration/StdioIntegrationSpec.scala
+++ b/client/src/test/scala/chimp/client/integration/StdioIntegrationSpec.scala
@@ -35,6 +35,8 @@ abstract class StdioIntegrationSpec[F[_]]
   )(test: BidirectionalMcpClient[F] => F[Assertion]): Future[Assertion] =
     toFuture(
       usingTransport(everythingServerCommand): transport =>
-        McpClient[F](transport, clientInfo, rootsHandler, samplingHandler, elicitationHandler, ProtocolVersion.Latest).flatMap: client =>
-          test(client).flatMap(assertion => client.close().map(_ => assertion))
+        McpClient
+          .bidirectional[F](transport, clientInfo, rootsHandler, samplingHandler, elicitationHandler, ProtocolVersion.Latest)
+          .flatMap: client =>
+            test(client).flatMap(assertion => client.close().map(_ => assertion))
     )

--- a/client/src/test/scala/chimp/client/integration/StreamingHttpIntegrationSpec.scala
+++ b/client/src/test/scala/chimp/client/integration/StreamingHttpIntegrationSpec.scala
@@ -41,7 +41,8 @@ abstract class StreamingHttpIntegrationSpec[F[_], B]
     toFuture(
       usingBackend: backend =>
         usingBidirectionalTransport(backend, mcpEverythingContainer.mcpUri, 60.seconds): transport =>
-          McpClient[F](transport, clientInfo, rootsHandler, samplingHandler, elicitationHandler, ProtocolVersion.Latest)
+          McpClient
+            .bidirectional[F](transport, clientInfo, rootsHandler, samplingHandler, elicitationHandler, ProtocolVersion.Latest)
             .flatMap: client =>
               test(client).flatMap(assertion => client.close().map(_ => assertion))
     )
@@ -55,7 +56,8 @@ abstract class StreamingHttpIntegrationSpec[F[_], B]
     toFuture(
       usingBackend: backend =>
         usingBidirectionalTransport(backend, proxyContainer.mcpUri, timeout): transport =>
-          McpClient[F](transport, clientInfo, None, samplingHandler, None, ProtocolVersion.Latest)
+          McpClient
+            .bidirectional[F](transport, clientInfo, None, samplingHandler, None, ProtocolVersion.Latest)
             .flatMap: client =>
               test(proxyContainer, client).flatMap(assertion => client.close().map(_ => assertion))
     )

--- a/client/src/test/scala/chimp/client/integration/StreamingHttpIntegrationSpec.scala
+++ b/client/src/test/scala/chimp/client/integration/StreamingHttpIntegrationSpec.scala
@@ -8,7 +8,7 @@ import sttp.model.Uri
 import sttp.monad.syntax.*
 
 import scala.concurrent.Future
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.duration.FiniteDuration
 
 abstract class StreamingHttpIntegrationSpec[F[_], B]
     extends HttpIntegrationSpec[F, B]
@@ -29,7 +29,7 @@ abstract class StreamingHttpIntegrationSpec[F[_], B]
   def usingBidirectionalTransport[A](b: B, uri: Uri, timeout: FiniteDuration)(use: BidirectionalTransport[F] => F[A]): F[A]
 
   override def usingTransport[A](backend: B, uri: Uri)(use: Transport[F] => F[A]): F[A] =
-    usingBidirectionalTransport(backend, uri, 60.seconds)(use)
+    usingBidirectionalTransport(backend, uri, Transport.defaultTimeout)(use)
 
   private val clientInfo = Implementation(name = "chimp-integration", version = "0.0.1")
 
@@ -40,7 +40,7 @@ abstract class StreamingHttpIntegrationSpec[F[_], B]
   )(test: BidirectionalMcpClient[F] => F[Assertion]): Future[Assertion] =
     toFuture(
       usingBackend: backend =>
-        usingBidirectionalTransport(backend, mcpEverythingContainer.mcpUri, 60.seconds): transport =>
+        usingBidirectionalTransport(backend, mcpEverythingContainer.mcpUri, Transport.defaultTimeout): transport =>
           McpClient
             .bidirectional[F](transport, clientInfo, rootsHandler, samplingHandler, elicitationHandler, ProtocolVersion.Latest)
             .flatMap: client =>
@@ -49,7 +49,7 @@ abstract class StreamingHttpIntegrationSpec[F[_], B]
 
   override protected def withProxiedBidirectionalClient(
       samplingHandler: Option[CreateMessageRequest => F[CreateMessageResult]] = None,
-      timeout: FiniteDuration = 60.seconds
+      timeout: FiniteDuration = Transport.defaultTimeout
   )(test: (MCPProxyContainer, BidirectionalMcpClient[F]) => F[Assertion]): Future[Assertion] =
     proxyContainer.restoreConnections()
     proxyContainer.clearToxics()

--- a/client/src/test/scala/chimp/client/integration/SyncStdioIntegrationSpec.scala
+++ b/client/src/test/scala/chimp/client/integration/SyncStdioIntegrationSpec.scala
@@ -3,9 +3,13 @@ package chimp.client.integration
 import chimp.client.transport.{BidirectionalTransport, StdioTransport}
 import sttp.shared.Identity
 
+import scala.concurrent.duration.FiniteDuration
+
 class SyncStdioIntegrationSpec extends StdioIntegrationSpec[Identity] with SyncToFuture:
 
-  override def usingTransport[A](command: List[String])(use: BidirectionalTransport[Identity] => Identity[A]): Identity[A] =
-    val transport = StdioTransport(command)
+  override def usingTransport[A](command: List[String], timeout: FiniteDuration)(
+      use: BidirectionalTransport[Identity] => Identity[A]
+  ): Identity[A] =
+    val transport = StdioTransport(command, timeout = timeout)
     try use(transport)
     finally transport.close()


### PR DESCRIPTION
DONE: 
* add basic scaladoc for MCP client and related components

MISC:
* refactor timeout handling using custom `McpTimeoutException`, make it part of stdio transport parameters and add test to check it's respected
* remove stream evidence from `StreamingStdioTransport` as it makes sense only for `StreamingHttpTransport` where appropriate sttp backend is required

Groundwork for https://github.com/softwaremill/chimp/issues/154.