### PR TITLE
Add sphinx-llms-txt to generate llms.txt and llms-full.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,8 @@ project/metals.sbt
 
 # OS
 .DS_Store
-Thumbs.db 
+Thumbs.db
+
+# Local Sphinx build artifacts
+generated-docs/out/.venv/
+generated-docs/out/_build/ 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,10 @@
 import os
 
 # Define the canonical URL if you are using a custom domain on Read the Docs
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+html_baseurl = os.environ.get(
+    "READTHEDOCS_CANONICAL_URL",
+    "https://chimp.softwaremill.com/",
+)
 
 # Tell Jinja2 templates the build is running on Read the Docs
 if os.environ.get("READTHEDOCS", "") == "True":
@@ -28,9 +31,13 @@ if os.environ.get("READTHEDOCS", "") == "True":
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['myst_parser', 'sphinx_rtd_theme', 'sphinxcontrib.mermaid']
+extensions = ['myst_parser', 'sphinx_rtd_theme', 'sphinxcontrib.mermaid', 'sphinx_llms_txt']
 
 myst_enable_extensions = ['attrs_block']
+
+llms_txt_title = "chimp"
+llms_txt_summary = "SDK for building MCP (Model Context Protocol) servers and clients in Scala 3"
+llms_txt_full_file = True
 
 # The suffix(es) of source filenames.
 source_suffix = {
@@ -60,7 +67,16 @@ language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.md', '.venv']
+exclude_patterns = [
+    '_build', 'Thumbs.db', '.DS_Store',
+    '.venv', 'venv', 'env',
+    '**/site-packages/**',
+    '**/node_modules/**',
+    '_templates',
+    'requirements.txt',
+    'README.md',
+    'includes/*',
+]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'default'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ sphinx==7.3.7
 sphinx-autobuild==2024.4.16
 myst-parser==2.0.0
 sphinxcontrib-mermaid==0.9.2
+sphinx-llms-txt

--- a/generated-docs/out/conf.py
+++ b/generated-docs/out/conf.py
@@ -15,7 +15,10 @@
 import os
 
 # Define the canonical URL if you are using a custom domain on Read the Docs
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+html_baseurl = os.environ.get(
+    "READTHEDOCS_CANONICAL_URL",
+    "https://chimp.softwaremill.com/",
+)
 
 # Tell Jinja2 templates the build is running on Read the Docs
 if os.environ.get("READTHEDOCS", "") == "True":
@@ -28,9 +31,13 @@ if os.environ.get("READTHEDOCS", "") == "True":
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['myst_parser', 'sphinx_rtd_theme', 'sphinxcontrib.mermaid']
+extensions = ['myst_parser', 'sphinx_rtd_theme', 'sphinxcontrib.mermaid', 'sphinx_llms_txt']
 
 myst_enable_extensions = ['attrs_block']
+
+llms_txt_title = "chimp"
+llms_txt_summary = "SDK for building MCP (Model Context Protocol) servers and clients in Scala 3"
+llms_txt_full_file = True
 
 # The suffix(es) of source filenames.
 source_suffix = {
@@ -60,7 +67,16 @@ language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.md', '.venv']
+exclude_patterns = [
+    '_build', 'Thumbs.db', '.DS_Store',
+    '.venv', 'venv', 'env',
+    '**/site-packages/**',
+    '**/node_modules/**',
+    '_templates',
+    'requirements.txt',
+    'README.md',
+    'includes/*',
+]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'default'

--- a/generated-docs/out/requirements.txt
+++ b/generated-docs/out/requirements.txt
@@ -3,3 +3,4 @@ sphinx==7.3.7
 sphinx-autobuild==2024.4.16
 myst-parser==2.0.0
 sphinxcontrib-mermaid==0.9.2
+sphinx-llms-txt


### PR DESCRIPTION
## Summary
Adds [`sphinx-llms-txt`](https://github.com/jdillard/sphinx-llms-txt) to the Sphinx documentation build so that `llms.txt` and `llms-full.txt` are generated automatically alongside the existing HTML output.

[`llms.txt`](https://llmstxt.org) is a standard for making documentation consumable by LLMs — `llms.txt` is a structured index of doc pages with links, and `llms-full.txt` is the full documentation concatenated into a single plain-text file.
Once merged, the files will be served at:
- https://chimp.softwaremill.com/llms.txt
- https://chimp.softwaremill.com/llms-full.txt

## Changes
 - `doc/requirements.txt` / `generated-doc/out/requirements.txt` — add `sphinx-llms-txt`
 - `doc/conf.py` / `generated-doc/out/conf.py`:
 - Add `sphinx_llms_txt` extension with title, summary, and `llms-full.txt` enabled
 - Remove `.txt` from `source_suffix` (was causing `requirements.txt` to appear as a doc page)
 - Tighten `exclude_patterns` to prevent venv, node_modules, `_templates`, `includes/*` partials, and `requirements.txt` from being treated as source documents
 - Add fallback to `html_baseurl` so local builds also produce absolute links

 No changes to `.readthedocs.yaml` - ReadTheDocs already installs from `generated-doc/out/requirements.txt` and runs Sphinx on `generated-doc/out/conf.py`, so the new files will be generated on every ReadTheDocs build automatically.