### PR TITLE
Bound the length of an incoming stdio line in every transport

### DIFF
--- a/client-streaming/client-ox/src/main/scala/chimp/client/transport/ox/OxClientStdioTransport.scala
+++ b/client-streaming/client-ox/src/main/scala/chimp/client/transport/ox/OxClientStdioTransport.scala
@@ -4,6 +4,7 @@ import chimp.client.McpTransportException
 import chimp.client.internal.SyncPendingRequests
 import chimp.client.transport.{ClientStreamingStdioTransport, ClientTransport}
 import chimp.protocol.JSONRPCMessage
+import chimp.transport.{StdioFraming, StdioLineReader}
 import org.slf4j.LoggerFactory
 import ox.*
 import ox.channels.{Actor, ActorRef}
@@ -77,15 +78,14 @@ final class OxClientStdioTransport private (
     case err: JSONRPCMessage.Error         => val _ = pending.complete(err.id, err)
     case other                             => state.ask(_.incoming)(other)
 
-  private def readLoop(reader: BufferedReader): Unit =
+  private def readLoop(reader: StdioLineReader): Unit =
     try
-      var line = reader.readLine()
-      while line != null do
-        if line.nonEmpty then
+      reader.lines
+        .filter(_.nonEmpty)
+        .foreach: line =>
           ClientTransport.decode(line) match
             case Right(msg) => dispatch(msg)
             case Left(e)    => log.warn(s"Failed to parse JSON-RPC line: ${e.getMessage}; raw: $line")
-        line = reader.readLine()
     catch case e: Exception => if !state.ask(_.closed) then log.warn(s"Reader loop ended: ${e.getMessage}")
     finally pending.closeAll("Transport closed")
 
@@ -103,7 +103,8 @@ object OxClientStdioTransport:
       command: List[String],
       env: Map[String, String] = Map.empty,
       workDir: Option[File] = None,
-      timeout: FiniteDuration = ClientTransport.defaultTimeout
+      timeout: FiniteDuration = ClientTransport.defaultTimeout,
+      maxLineLength: Int = StdioFraming.defaultMaxLineLength
   )(using Ox): OxClientStdioTransport =
     val pb = ProcessBuilder(command.asJava)
     workDir.foreach(pb.directory)
@@ -117,7 +118,7 @@ object OxClientStdioTransport:
 
     val transport = new OxClientStdioTransport(command, env, workDir, timeout, process, SyncPendingRequests())
 
-    val reader = BufferedReader(InputStreamReader(process.getInputStream, StandardCharsets.UTF_8))
+    val reader = StdioLineReader(process.getInputStream, maxLineLength)
     val errReader = BufferedReader(InputStreamReader(process.getErrorStream, StandardCharsets.UTF_8))
     forkDiscard(transport.readLoop(reader))
     forkDiscard(transport.drainStderr(errReader))

--- a/client-streaming/client-pekko/src/main/scala/chimp/client/transport/pekko/PekkoClientStdioTransport.scala
+++ b/client-streaming/client-pekko/src/main/scala/chimp/client/transport/pekko/PekkoClientStdioTransport.scala
@@ -4,6 +4,7 @@ import chimp.client.McpTransportException
 import chimp.client.transport.pekko.internal.{PekkoPendingRequests, StateActor}
 import chimp.client.transport.{ClientStreamingStdioTransport, ClientTransport}
 import chimp.protocol.JSONRPCMessage
+import chimp.transport.{McpLineTooLongException, StdioFraming}
 import org.apache.pekko.stream.scaladsl.{Framing, Sink, Source, StreamConverters}
 import org.apache.pekko.stream.{BoundedSourceQueue, Materializer, QueueOfferResult}
 import org.apache.pekko.util.ByteString
@@ -22,6 +23,7 @@ final class PekkoClientStdioTransport private (
     workDir: Option[File],
     timeout: FiniteDuration,
     process: Process,
+    maxLineLength: Int,
     outbound: BoundedSourceQueue[JSONRPCMessage],
     pending: PekkoPendingRequests
 )(using mat: Materializer)
@@ -102,7 +104,7 @@ final class PekkoClientStdioTransport private (
 
   private[pekko] def startReader(): Unit =
     val done = PekkoClientStdioTransport
-      .lines(process.getInputStream)
+      .lines(process.getInputStream, maxLineLength)
       .mapAsync(1): line =>
         ClientTransport.decode(line) match
           case Right(msg) => dispatch(msg)
@@ -119,11 +121,10 @@ final class PekkoClientStdioTransport private (
 
   private[pekko] def startStderr(): Unit =
     val _ = PekkoClientStdioTransport
-      .lines(process.getErrorStream)
+      .lines(process.getErrorStream, maxLineLength)
       .runForeach(line => log.info(s"stdio-server: $line"))
 
 object PekkoClientStdioTransport:
-  private val maxLineLength = 8 * 1024 * 1024
   private val outboundBufferSize = 256
   private val exitTimeout = 2.seconds
 
@@ -137,12 +138,15 @@ object PekkoClientStdioTransport:
     *   The working directory of the subprocess; by default inherited from the current process.
     * @param timeout
     *   How long to wait for a response to a request sent to the server.
+    * @param maxLineLength
+    *   The maximum length of a single line received from the subprocess, in bytes. A longer line closes the transport.
     */
   def apply(
       command: List[String],
       env: Map[String, String] = Map.empty,
       workDir: Option[File] = None,
-      timeout: FiniteDuration = ClientTransport.defaultTimeout
+      timeout: FiniteDuration = ClientTransport.defaultTimeout,
+      maxLineLength: Int = StdioFraming.defaultMaxLineLength
   )(using Materializer): PekkoClientStdioTransport =
     val builder = ProcessBuilder(command.asJava)
     workDir.foreach(builder.directory)
@@ -160,14 +164,16 @@ object PekkoClientStdioTransport:
       .to(StreamConverters.fromOutputStream(() => process.getOutputStream, autoFlush = true))
       .run()
 
-    val transport = new PekkoClientStdioTransport(command, env, workDir, timeout, process, outbound, PekkoPendingRequests())
+    val transport =
+      new PekkoClientStdioTransport(command, env, workDir, timeout, process, maxLineLength, outbound, PekkoPendingRequests())
     transport.startReader()
     transport.startStderr()
     transport
 
-  private def lines(in: InputStream): Source[String, ?] =
+  private def lines(in: InputStream, maxLineLength: Int): Source[String, ?] =
     StreamConverters
       .fromInputStream(() => in)
       .via(Framing.delimiter(ByteString("\n"), maximumFrameLength = maxLineLength, allowTruncation = true))
+      .mapError { case _: Framing.FramingException => McpLineTooLongException(maxLineLength) }
       .map(_.utf8String.trim)
       .filter(_.nonEmpty)

--- a/client-streaming/client-zio/src/main/scala/chimp/client/transport/zio/ZioClientStdioTransport.scala
+++ b/client-streaming/client-zio/src/main/scala/chimp/client/transport/zio/ZioClientStdioTransport.scala
@@ -2,6 +2,7 @@ package chimp.client.transport.zio
 
 import chimp.client.transport.{ClientStreamingStdioTransport, ClientTransport}
 import chimp.protocol.JSONRPCMessage
+import chimp.transport.{McpLineTooLongException, StdioFraming}
 import org.slf4j.LoggerFactory
 import sttp.client4.impl.zio.RIOMonadAsyncError
 import sttp.monad.MonadError
@@ -11,6 +12,7 @@ import zio.{Chunk, Exit, Queue, Ref, Scope, Task, ZIO, ZLayer}
 
 import java.io.File
 import java.nio.charset.StandardCharsets
+import scala.annotation.tailrec
 import scala.concurrent.duration.FiniteDuration
 
 final class ZioClientStdioTransport private (
@@ -20,6 +22,7 @@ final class ZioClientStdioTransport private (
     timeout: FiniteDuration,
     scope: Scope.Closeable,
     process: Process,
+    maxLineLength: Int,
     writeQueue: Queue[JSONRPCMessage],
     pending: ZioPendingRequests,
     incomingRef: Ref[JSONRPCMessage => Task[Unit]]
@@ -51,8 +54,8 @@ final class ZioClientStdioTransport private (
     case other                             => incomingRef.get.flatMap(_(other))
 
   private[zio] def startReader: Task[Unit] =
-    val drain = process.stdout.linesStream
-      .filter(_.nonEmpty)
+    val drain = ZioClientStdioTransport
+      .lines(process.stdout.stream, maxLineLength)
       .mapZIO: line =>
         ClientTransport.decode(line) match
           case Right(msg) => dispatch(msg)
@@ -74,7 +77,8 @@ object ZioClientStdioTransport:
       command: List[String],
       env: Map[String, String] = Map.empty,
       workDir: Option[File] = None,
-      timeout: FiniteDuration = ClientTransport.defaultTimeout
+      timeout: FiniteDuration = ClientTransport.defaultTimeout,
+      maxLineLength: Int = StdioFraming.defaultMaxLineLength
   ): Task[ZioClientStdioTransport] =
     for
       scope <- Scope.make
@@ -90,7 +94,8 @@ object ZioClientStdioTransport:
       withDir = workDir.fold(withEnv)(withEnv.workingDirectory)
       cmd = withDir.stdin(ProcessInput.fromStream(stdinBytes, flushChunksEagerly = true))
       process <- cmd.run.provideEnvironment(zio.ZEnvironment(scope))
-      transport = new ZioClientStdioTransport(command, env, workDir, timeout, scope, process, writeQueue, pending, incomingRef)
+      transport =
+        new ZioClientStdioTransport(command, env, workDir, timeout, scope, process, maxLineLength, writeQueue, pending, incomingRef)
       _ <- transport.startReader
       _ <- transport.startStderr
     yield transport
@@ -99,14 +104,38 @@ object ZioClientStdioTransport:
       command: List[String],
       env: Map[String, String] = Map.empty,
       workDir: Option[File] = None,
-      timeout: FiniteDuration = ClientTransport.defaultTimeout
+      timeout: FiniteDuration = ClientTransport.defaultTimeout,
+      maxLineLength: Int = StdioFraming.defaultMaxLineLength
   ): ZIO[Scope, Throwable, ZioClientStdioTransport] =
-    ZIO.acquireRelease(apply(command, env, workDir, timeout))(_.close().ignore)
+    ZIO.acquireRelease(apply(command, env, workDir, timeout, maxLineLength))(_.close().ignore)
 
   def layer(
       command: List[String],
       env: Map[String, String] = Map.empty,
       workDir: Option[File] = None,
-      timeout: FiniteDuration = ClientTransport.defaultTimeout
+      timeout: FiniteDuration = ClientTransport.defaultTimeout,
+      maxLineLength: Int = StdioFraming.defaultMaxLineLength
   ): ZLayer[Any, Throwable, ZioClientStdioTransport] =
-    ZLayer.scoped(scoped(command, env, workDir, timeout))
+    ZLayer.scoped(scoped(command, env, workDir, timeout, maxLineLength))
+
+  private[zio] def lines(bytes: ZStream[Any, Throwable, Byte], maxLineLength: Int): ZStream[Any, Throwable, String] =
+    bytes.chunks
+      .concat(ZStream.succeed(Chunk.single(StdioFraming.newline)))
+      .mapAccumZIO(Chunk.empty[Byte]): (buffered, chunk) =>
+        split(buffered ++ chunk, maxLineLength) match
+          case Some(framed) => ZIO.succeed(framed)
+          case None         => ZIO.fail(McpLineTooLongException(maxLineLength))
+      .flattenChunks
+      .filter(_.nonEmpty)
+
+  private def split(bytes: Chunk[Byte], maxLineLength: Int): Option[(Chunk[Byte], Chunk[String])] =
+    @tailrec
+    def loop(remaining: Chunk[Byte], lines: Chunk[String]): Option[(Chunk[Byte], Chunk[String])] =
+      remaining.indexWhere(_ == StdioFraming.newline) match
+        case -1                       => if remaining.size > maxLineLength then None else Some((remaining, lines))
+        case at if at > maxLineLength => None
+        case at                       =>
+          val (line, rest) = remaining.splitAt(at)
+          loop(rest.drop(1), lines :+ StdioFraming.decodeLine(line.toArray))
+
+    loop(bytes, Chunk.empty)

--- a/client-streaming/client-zio/src/test/scala/chimp/client/transport/zio/ZioClientStdioLinesSpec.scala
+++ b/client-streaming/client-zio/src/test/scala/chimp/client/transport/zio/ZioClientStdioLinesSpec.scala
@@ -1,0 +1,55 @@
+package chimp.client.transport.zio
+
+import chimp.transport.McpLineTooLongException
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import zio.Chunk
+import zio.stream.ZStream
+
+import java.nio.charset.StandardCharsets
+import scala.concurrent.Future
+
+class ZioClientStdioLinesSpec extends AsyncFlatSpec with Matchers with ZioToFuture:
+
+  private def lines(text: String, maxLineLength: Int = 1024, chunkSize: Int = Int.MaxValue): Future[List[String]] =
+    toFuture(ZioClientStdioTransport.lines(bytes(text, chunkSize), maxLineLength).runCollect).map(_.toList)
+
+  private def failure(text: String, maxLineLength: Int, chunkSize: Int = Int.MaxValue): Future[Throwable] =
+    toFuture(ZioClientStdioTransport.lines(bytes(text, chunkSize), maxLineLength).runCollect.either).map:
+      case Left(thrown) => thrown
+      case Right(lines) => fail(s"Expected a failure, got the lines: $lines")
+
+  private def bytes(text: String, chunkSize: Int): ZStream[Any, Throwable, Byte] =
+    val all = Chunk.fromArray(text.getBytes(StandardCharsets.UTF_8))
+    if chunkSize == Int.MaxValue then ZStream.fromChunk(all) else ZStream.fromChunk(all).rechunk(chunkSize)
+
+  "the zio stdio framing" should "split the newline-delimited lines" in:
+    lines("one\ntwo\nthree\n").map(_ shouldBe List("one", "two", "three"))
+
+  it should "emit the last line when the input does not end with a newline" in:
+    lines("one\ntwo").map(_ shouldBe List("one", "two"))
+
+  it should "skip the empty lines" in:
+    lines("one\n\ntwo\n").map(_ shouldBe List("one", "two"))
+
+  it should "drop a carriage return before the newline" in:
+    lines("one\r\ntwo\r\n").map(_ shouldBe List("one", "two"))
+
+  it should "join the lines split across chunks" in:
+    lines("""{"message":"zażółć gęślą jaźń"}""" + "\nnext\n", chunkSize = 1)
+      .map(_ shouldBe List("""{"message":"zażółć gęślą jaźń"}""", "next"))
+
+  it should "accept a line of exactly the maximum length" in:
+    val line = "x" * 64
+    lines(s"$line\n", maxLineLength = 64).map(_ shouldBe List(line))
+
+  it should "fail on a line longer than the maximum length" in:
+    failure("x" * 65 + "\n", maxLineLength = 64).map: thrown =>
+      thrown shouldBe a[McpLineTooLongException]
+      thrown.asInstanceOf[McpLineTooLongException].maxLineLength shouldBe 64
+
+  it should "fail on a line longer than the maximum length which never ends" in:
+    failure("x" * 65, maxLineLength = 64, chunkSize = 1).map(_ shouldBe a[McpLineTooLongException])
+
+  it should "count the bytes of multi-byte characters" in:
+    failure("ą" * 33 + "\n", maxLineLength = 64).map(_ shouldBe a[McpLineTooLongException])

--- a/client/src/main/scala/chimp/client/transport/ClientStdioTransport.scala
+++ b/client/src/main/scala/chimp/client/transport/ClientStdioTransport.scala
@@ -2,6 +2,7 @@ package chimp.client.transport
 
 import chimp.client.internal.SyncPendingRequests
 import chimp.protocol.JSONRPCMessage
+import chimp.transport.{StdioFraming, StdioLineReader}
 import org.slf4j.LoggerFactory
 import sttp.monad.{IdentityMonad, MonadError}
 import sttp.shared.Identity
@@ -24,12 +25,15 @@ import scala.jdk.CollectionConverters.*
   *   Optional working directory for the subprocess.
   * @param timeout
   *   Maximum time to wait for a response to each request before raising an [[chimp.client.McpTimeoutException]].
+  * @param maxLineLength
+  *   The maximum length of a single line received from the subprocess, in bytes. A longer line closes the transport.
   */
 final class ClientStdioTransport(
     command: List[String],
     env: Map[String, String] = Map.empty,
     workDir: Option[File] = None,
-    timeout: FiniteDuration = ClientTransport.defaultTimeout
+    timeout: FiniteDuration = ClientTransport.defaultTimeout,
+    maxLineLength: Int = StdioFraming.defaultMaxLineLength
 ) extends ClientBidirectionalTransport[Identity]:
 
   private val log = LoggerFactory.getLogger(classOf[ClientStdioTransport])
@@ -46,7 +50,7 @@ final class ClientStdioTransport(
     pb.start()
 
   private val writer = BufferedWriter(OutputStreamWriter(proc.getOutputStream, StandardCharsets.UTF_8))
-  private val reader = BufferedReader(InputStreamReader(proc.getInputStream, StandardCharsets.UTF_8))
+  private val reader = StdioLineReader(proc.getInputStream, maxLineLength)
   private val errReader = BufferedReader(InputStreamReader(proc.getErrorStream, StandardCharsets.UTF_8))
 
   private val pending = SyncPendingRequests()
@@ -65,13 +69,12 @@ final class ClientStdioTransport(
 
   private def readLoop(): Unit =
     try
-      var line: String = reader.readLine()
-      while line != null do
-        if line.nonEmpty then
+      reader.lines
+        .filter(_.nonEmpty)
+        .foreach: line =>
           ClientTransport.decode(line) match
             case Right(msg) => dispatch(msg)
             case Left(e)    => log.warn(s"Failed to parse JSON-RPC line: ${e.getMessage}; raw: $line")
-        line = reader.readLine()
     catch case e: Exception => if !closed.get() then log.warn(s"Reader loop ended: ${e.getMessage}")
     finally pending.closeAll("Transport closed")
 

--- a/core/src/main/scala/chimp/transport/StdioFraming.scala
+++ b/core/src/main/scala/chimp/transport/StdioFraming.scala
@@ -1,0 +1,34 @@
+package chimp.transport
+
+import java.io.{BufferedInputStream, ByteArrayOutputStream, InputStream}
+import java.nio.charset.StandardCharsets
+
+final class McpLineTooLongException(val maxLineLength: Int)
+    extends RuntimeException(s"An incoming line is longer than the maximum of $maxLineLength bytes")
+
+object StdioFraming:
+
+  val defaultMaxLineLength: Int = 10 * 1024 * 1024
+
+  private[chimp] val newline: Byte = '\n'.toByte
+
+  private[chimp] def decodeLine(bytes: Array[Byte]): String =
+    val end = if bytes.length > 0 && bytes(bytes.length - 1) == '\r'.toByte then bytes.length - 1 else bytes.length
+    String(bytes, 0, end, StandardCharsets.UTF_8)
+
+private[chimp] final class StdioLineReader(in: InputStream, maxLineLength: Int):
+  private val buffered = BufferedInputStream(in)
+  private val line = ByteArrayOutputStream()
+
+  def readLine(): Option[String] =
+    var next = buffered.read()
+    if next < 0 then None
+    else
+      line.reset()
+      while next >= 0 && next != StdioFraming.newline do
+        if line.size() >= maxLineLength then throw McpLineTooLongException(maxLineLength)
+        line.write(next)
+        next = buffered.read()
+      Some(StdioFraming.decodeLine(line.toByteArray))
+
+  def lines: Iterator[String] = Iterator.continually(readLine()).takeWhile(_.isDefined).flatten

--- a/core/src/test/scala/chimp/transport/StdioLineReaderSpec.scala
+++ b/core/src/test/scala/chimp/transport/StdioLineReaderSpec.scala
@@ -1,0 +1,50 @@
+package chimp.transport
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
+class StdioLineReaderSpec extends AnyFlatSpec with Matchers:
+
+  private def reader(input: String, maxLineLength: Int = 1024): StdioLineReader =
+    StdioLineReader(ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)), maxLineLength)
+
+  "a stdio line reader" should "read newline-delimited lines" in:
+    reader("one\ntwo\nthree\n").lines.toList shouldBe List("one", "two", "three")
+
+  it should "read the last line when the input does not end with a newline" in:
+    reader("one\ntwo").lines.toList shouldBe List("one", "two")
+
+  it should "keep the empty lines" in:
+    reader("one\n\ntwo\n").lines.toList shouldBe List("one", "", "two")
+
+  it should "drop a carriage return before the newline" in:
+    reader("one\r\ntwo\r\n").lines.toList shouldBe List("one", "two")
+
+  it should "decode multi-byte characters" in:
+    reader("""{"message":"zażółć gęślą jaźń"}""" + "\n").lines.toList shouldBe List("""{"message":"zażółć gęślą jaźń"}""")
+
+  it should "report the end of the input" in:
+    val r = reader("one\n")
+    r.readLine() shouldBe Some("one")
+    r.readLine() shouldBe None
+
+  it should "report the end of an empty input" in:
+    reader("").readLine() shouldBe None
+
+  it should "accept a line of exactly the maximum length" in:
+    val line = "x" * 64
+    reader(s"$line\n", maxLineLength = 64).lines.toList shouldBe List(line)
+
+  it should "fail on a line longer than the maximum length" in:
+    val failure = intercept[McpLineTooLongException](reader("x" * 65 + "\n", maxLineLength = 64).lines.toList)
+    failure.maxLineLength shouldBe 64
+    failure.getMessage should include("64")
+
+  it should "fail on a line longer than the maximum length which never ends" in:
+    intercept[McpLineTooLongException](reader("x" * 65, maxLineLength = 64).lines.toList)
+
+  it should "count the bytes of multi-byte characters" in:
+    intercept[McpLineTooLongException](reader("ą" * 33 + "\n", maxLineLength = 64).lines.toList)

--- a/docs/client/transport.md
+++ b/docs/client/transport.md
@@ -48,3 +48,21 @@ The streaming transports have concrete implementations per effect system, in sep
 
 - **HTTP** transports run on any [sttp](https://sttp.softwaremill.com/en/latest/) backend. The streaming HTTP transports additionally require a backend with streaming capability.
 - **STDIO** transports, on the other hand, can run using plain JDK components (synchronous), or using various libraries that support asynchronous streaming.
+
+## Message size limits
+
+The **STDIO** transports bound a single line read from the subprocess with `maxLineLength`, 10 MB by default. A longer line closes the transport: the reader stops and the requests waiting for a response fail.
+
+```scala mdoc:compile-only
+import chimp.client.*
+import chimp.client.transport.ClientStdioTransport
+import chimp.protocol.Implementation
+import sttp.shared.Identity
+
+object BoundedStdioClient:
+  def main(args: Array[String]): Unit =
+    val transport = ClientStdioTransport(command = List("my-mcp-server"), maxLineLength = 4 * 1024 * 1024)
+    val client = McpClient[Identity](transport, Implementation("my-client", "0.1.0"))
+
+    client.close()
+```

--- a/docs/server/transport.md
+++ b/docs/server/transport.md
@@ -50,6 +50,39 @@ The streaming transports have concrete implementations per effect system, in sep
 - **HTTP** transports produce a Tapir `ServerEndpoint` that you run on any Tapir server interpreter. The streaming HTTP transport additionally requires an interpreter with streaming capability.
 - **STDIO** transports run the read/dispatch/write loop using plain JDK components (synchronous), or an effect's own semantics.
 
+## Message size limits
+
+The MCP specification sets no limit on the size of a message.
+
+**STDIO** transports read newline-delimited messages and bound a single incoming line with `maxLineLength`, 10 MB by default. A longer line fails the serve loop with a `chimp.transport.McpLineTooLongException` on every backend:
+
+```scala mdoc:compile-only
+import chimp.server.*
+import chimp.server.transport.ServerStdioTransport
+
+object BoundedStdioServer:
+  def main(args: Array[String]): Unit =
+    val echo = tool("echo").input[String].handle(echo => ToolResult.text(echo))
+    ServerStdioTransport(maxLineLength = 4 * 1024 * 1024).serve(McpServer(tools = List(echo)))
+```
+
+**HTTP** transports produce a Tapir endpoint, so the limit is Tapir's `maxRequestBodyLength`. A longer body gets `413 Payload Too Large`:
+
+```scala mdoc:compile-only
+import chimp.server.*
+import sttp.tapir.server.model.EndpointExtensions.*
+import sttp.tapir.server.netty.sync.NettySyncServer
+
+object BoundedHttpServer:
+  def main(args: Array[String]): Unit =
+    val echo = tool("echo").input[String].handle(echo => ToolResult.text(echo))
+    val mcpEndpoint = McpServer(tools = List(echo)).endpoint(List("mcp")).maxRequestBodyLength(4 * 1024 * 1024)
+
+    NettySyncServer().port(8080).addEndpoint(mcpEndpoint).startAndWait()
+```
+
+Some server interpreters have a limit of their own, refer to their configuration if needed. For example Pekko HTTP `pekko.http.server.parsing.max-content-length` defaults to 8 MB.
+
 ## Security
 
 An HTTP transport produces a plain Tapir `ServerEndpoint`, so you can protect the MCP endpoint with Tapir's endpoint security. `prependSecurity` (or `prependSecurityPure`, if the check needs no effect) adds a security input and the logic which validates it. The logic runs before any MCP message is handled:

--- a/server-streaming/server-ox/src/main/scala/chimp/server/ox/OxServerStdioTransport.scala
+++ b/server-streaming/server-ox/src/main/scala/chimp/server/ox/OxServerStdioTransport.scala
@@ -3,6 +3,7 @@ package chimp.server.ox
 import chimp.protocol.{JSONRPCMessage, ProgressToken}
 import chimp.server.transport.ServerStreamingStdioTransport
 import chimp.server.{McpHandler, OutboundSink, SinkStreamingServerContext, StreamingMcpServer, StreamingServerContext}
+import chimp.transport.{StdioFraming, StdioLineReader}
 import io.circe.syntax.*
 import io.circe.{parser, Json}
 import org.slf4j.LoggerFactory
@@ -11,17 +12,20 @@ import ox.channels.Channel
 import sttp.monad.{IdentityMonad, MonadError}
 import sttp.shared.Identity
 
-import java.io.{BufferedReader, BufferedWriter, InputStream, InputStreamReader, OutputStream, OutputStreamWriter}
+import java.io.{BufferedWriter, InputStream, OutputStream, OutputStreamWriter}
 import java.nio.charset.StandardCharsets
 
-final class OxServerStdioTransport(in: InputStream = System.in, out: OutputStream = System.out)
-    extends ServerStreamingStdioTransport[Identity]:
+final class OxServerStdioTransport(
+    in: InputStream = System.in,
+    out: OutputStream = System.out,
+    maxLineLength: Int = StdioFraming.defaultMaxLineLength
+) extends ServerStreamingStdioTransport[Identity]:
   private val log = LoggerFactory.getLogger(classOf[OxServerStdioTransport])
 
   def serve(server: StreamingMcpServer[Identity]): Unit =
     given MonadError[Identity] = IdentityMonad
     val handler = new McpHandler[Identity, StreamingServerContext[Identity]](server)
-    val reader = BufferedReader(InputStreamReader(in, StandardCharsets.UTF_8))
+    val reader = StdioLineReader(in, maxLineLength)
     val writer = BufferedWriter(OutputStreamWriter(out, StandardCharsets.UTF_8))
 
     def writeLine(json: Json): Unit =
@@ -38,13 +42,12 @@ final class OxServerStdioTransport(in: InputStream = System.in, out: OutputStrea
       val makeContext: Option[ProgressToken] => StreamingServerContext[Identity] =
         token => SinkStreamingServerContext(sink, token)
 
-      var line = reader.readLine()
-      while line != null do
-        if line.nonEmpty then
+      reader.lines
+        .filter(_.nonEmpty)
+        .foreach: line =>
           parser.parse(line) match
             case Right(json) => handler.handleJsonRpc(json, Nil, makeContext).body.foreach(outbound.send)
             case Left(error) => log.warn(s"Failed to parse JSON-RPC line: ${error.getMessage}; raw: $line")
-        line = reader.readLine()
 
       outbound.done()
       writerFork.join()

--- a/server-streaming/server-ox/src/test/scala/chimp/server/ox/OxMcpServerStdioSpec.scala
+++ b/server-streaming/server-ox/src/test/scala/chimp/server/ox/OxMcpServerStdioSpec.scala
@@ -4,9 +4,20 @@ import chimp.server.{ServerStdioTransportTests, StreamingMcpServer, SyncToFuture
 import sttp.shared.Identity
 
 import java.io.{InputStream, OutputStream}
+import scala.concurrent.{Future, Promise}
+import scala.util.Try
 
 class OxMcpServerStdioSpec extends ServerStdioTransportTests[Identity] with SyncToFuture:
-  override protected def runStdioServer(server: StreamingMcpServer[Identity], in: InputStream, out: OutputStream): Unit =
-    val thread = Thread(() => OxServerStdioTransport(in, out).serve(server))
+  override protected def runStdioServer(
+      server: StreamingMcpServer[Identity],
+      in: InputStream,
+      out: OutputStream,
+      maxLineLength: Int
+  ): Future[Unit] =
+    val served = Promise[Unit]()
+    val thread = Thread { () =>
+      val _ = served.complete(Try(OxServerStdioTransport(in, out, maxLineLength).serve(server)))
+    }
     thread.setDaemon(true)
     thread.start()
+    served.future

--- a/server-streaming/server-pekko/src/main/scala/chimp/server/pekko/PekkoServerStdioTransport.scala
+++ b/server-streaming/server-pekko/src/main/scala/chimp/server/pekko/PekkoServerStdioTransport.scala
@@ -3,6 +3,7 @@ package chimp.server.pekko
 import chimp.protocol.{JSONRPCMessage, ProgressToken}
 import chimp.server.transport.ServerStreamingStdioTransport
 import chimp.server.{McpHandler, OutboundSink, SinkStreamingServerContext, StreamingMcpServer, StreamingServerContext}
+import chimp.transport.{McpLineTooLongException, StdioFraming}
 import io.circe.syntax.*
 import io.circe.{parser, Json}
 import org.apache.pekko.stream.scaladsl.{Framing, Keep, Sink, Source, SourceQueueWithComplete, StreamConverters}
@@ -14,7 +15,11 @@ import sttp.monad.{FutureMonad, MonadError}
 import java.io.{InputStream, OutputStream}
 import scala.concurrent.{ExecutionContext, Future}
 
-final class PekkoServerStdioTransport(in: InputStream = System.in, out: OutputStream = System.out)(using mat: Materializer)
+final class PekkoServerStdioTransport(
+    in: InputStream = System.in,
+    out: OutputStream = System.out,
+    maxLineLength: Int = StdioFraming.defaultMaxLineLength
+)(using mat: Materializer)
     extends ServerStreamingStdioTransport[Future]:
 
   private val log = LoggerFactory.getLogger(classOf[PekkoServerStdioTransport])
@@ -39,7 +44,8 @@ final class PekkoServerStdioTransport(in: InputStream = System.in, out: OutputSt
 
     val reading = StreamConverters
       .fromInputStream(() => in)
-      .via(Framing.delimiter(ByteString("\n"), maximumFrameLength = PekkoServerStdioTransport.maxLineLength, allowTruncation = true))
+      .via(Framing.delimiter(ByteString("\n"), maximumFrameLength = maxLineLength, allowTruncation = true))
+      .mapError { case _: Framing.FramingException => McpLineTooLongException(maxLineLength) }
       .map(_.utf8String.trim)
       .filter(_.nonEmpty)
       .mapAsync(1)(line => handleLine(handler, makeContext, outbound, line))
@@ -63,6 +69,3 @@ final class PekkoServerStdioTransport(in: InputStream = System.in, out: OutputSt
       case Left(error) =>
         log.warn(s"Failed to parse JSON-RPC line: ${error.getMessage}; raw: $line")
         Future.unit
-
-object PekkoServerStdioTransport:
-  private val maxLineLength = 8 * 1024 * 1024

--- a/server-streaming/server-pekko/src/test/scala/chimp/server/pekko/PekkoMcpServerStdioSpec.scala
+++ b/server-streaming/server-pekko/src/test/scala/chimp/server/pekko/PekkoMcpServerStdioSpec.scala
@@ -7,5 +7,10 @@ import scala.concurrent.Future
 
 class PekkoMcpServerStdioSpec extends ServerStdioTransportTests[Future] with PekkoToFuture:
 
-  override protected def runStdioServer(server: StreamingMcpServer[Future], in: InputStream, out: OutputStream): Unit =
-    val _ = PekkoServerStdioTransport(in, out).serve(server)
+  override protected def runStdioServer(
+      server: StreamingMcpServer[Future],
+      in: InputStream,
+      out: OutputStream,
+      maxLineLength: Int
+  ): Future[Unit] =
+    PekkoServerStdioTransport(in, out, maxLineLength).serve(server)

--- a/server-streaming/server-zio/src/main/scala/chimp/server/zio/ZioServerStdioTransport.scala
+++ b/server-streaming/server-zio/src/main/scala/chimp/server/zio/ZioServerStdioTransport.scala
@@ -3,6 +3,7 @@ package chimp.server.zio
 import chimp.protocol.{JSONRPCMessage, ProgressToken}
 import chimp.server.{McpHandler, OutboundSink, SinkStreamingServerContext, StreamingMcpServer, StreamingServerContext}
 import chimp.server.transport.ServerStreamingStdioTransport
+import chimp.transport.{StdioFraming, StdioLineReader}
 import io.circe.syntax.*
 import io.circe.{parser, Json}
 import org.slf4j.LoggerFactory
@@ -10,17 +11,20 @@ import sttp.monad.MonadError
 import sttp.tapir.ztapir.RIOMonadError
 import zio.{Task, ZIO}
 
-import java.io.{BufferedReader, BufferedWriter, InputStream, InputStreamReader, OutputStream, OutputStreamWriter}
+import java.io.{BufferedWriter, InputStream, OutputStream, OutputStreamWriter}
 import java.nio.charset.StandardCharsets
 
-final class ZioServerStdioTransport(in: InputStream = System.in, out: OutputStream = System.out)
-    extends ServerStreamingStdioTransport[Task]:
+final class ZioServerStdioTransport(
+    in: InputStream = System.in,
+    out: OutputStream = System.out,
+    maxLineLength: Int = StdioFraming.defaultMaxLineLength
+) extends ServerStreamingStdioTransport[Task]:
   private val log = LoggerFactory.getLogger(classOf[ZioServerStdioTransport])
   private given MonadError[Task] = new RIOMonadError[Any]
 
   def serve(server: StreamingMcpServer[Task]): Task[Unit] =
     val handler = new McpHandler[Task, StreamingServerContext[Task]](server)
-    val reader = BufferedReader(InputStreamReader(in, StandardCharsets.UTF_8))
+    val reader = StdioLineReader(in, maxLineLength)
     val writer = BufferedWriter(OutputStreamWriter(out, StandardCharsets.UTF_8))
 
     def writeLine(json: Json): Task[Unit] =
@@ -37,7 +41,7 @@ final class ZioServerStdioTransport(in: InputStream = System.in, out: OutputStre
 
     def loop: Task[Unit] =
       ZIO
-        .attemptBlocking(Option(reader.readLine()))
+        .attemptBlocking(reader.readLine())
         .flatMap:
           case None       => ZIO.unit
           case Some(line) =>

--- a/server-streaming/server-zio/src/test/scala/chimp/server/zio/ZioMcpServerStdioSpec.scala
+++ b/server-streaming/server-zio/src/test/scala/chimp/server/zio/ZioMcpServerStdioSpec.scala
@@ -1,18 +1,17 @@
 package chimp.server.zio
 
 import chimp.server.{ServerStdioTransportTests, StreamingMcpServer}
-import zio.{Runtime, Task, Unsafe}
+import zio.Task
 
 import java.io.{InputStream, OutputStream}
+import scala.concurrent.Future
 
 class ZioMcpServerStdioSpec extends ServerStdioTransportTests[Task] with ZioToFuture:
-  private val runtime = Runtime.default
 
-  override protected def runStdioServer(server: StreamingMcpServer[Task], in: InputStream, out: OutputStream): Unit =
-    val thread = Thread(() =>
-      Unsafe.unsafe { implicit u =>
-        runtime.unsafe.run(ZioServerStdioTransport(in, out).serve(server)).getOrThrowFiberFailure()
-      }
-    )
-    thread.setDaemon(true)
-    thread.start()
+  override protected def runStdioServer(
+      server: StreamingMcpServer[Task],
+      in: InputStream,
+      out: OutputStream,
+      maxLineLength: Int
+  ): Future[Unit] =
+    toFuture(ZioServerStdioTransport(in, out, maxLineLength).serve(server))

--- a/server/src/main/scala/chimp/server/transport/ServerStdioTransport.scala
+++ b/server/src/main/scala/chimp/server/transport/ServerStdioTransport.scala
@@ -2,13 +2,14 @@ package chimp.server.transport
 
 import chimp.protocol.{JSONRPCMessage, ProgressToken}
 import chimp.server.*
+import chimp.transport.{StdioFraming, StdioLineReader}
 import io.circe.parser
 import io.circe.syntax.*
 import org.slf4j.LoggerFactory
 import sttp.monad.{IdentityMonad, MonadError}
 import sttp.shared.Identity
 
-import java.io.{BufferedReader, BufferedWriter, InputStream, InputStreamReader, OutputStream, OutputStreamWriter}
+import java.io.{BufferedWriter, InputStream, OutputStream, OutputStreamWriter}
 import java.nio.charset.StandardCharsets
 
 /** A synchronous implementation of MCP server using stdio transport. Exchanges line-delimited JSON-RPC messages over its standard input and
@@ -18,9 +19,15 @@ import java.nio.charset.StandardCharsets
   *   Server input stream.
   * @param out
   *   Server output stream.
+  * @param maxLineLength
+  *   The maximum length of a single incoming line, in bytes. Reading a longer line fails the transport with a
+  *   [[chimp.transport.McpLineTooLongException]].
   */
-final class ServerStdioTransport(in: InputStream = System.in, out: OutputStream = System.out)
-    extends ServerTransport[Identity, Unit]
+final class ServerStdioTransport(
+    in: InputStream = System.in,
+    out: OutputStream = System.out,
+    maxLineLength: Int = StdioFraming.defaultMaxLineLength
+) extends ServerTransport[Identity, Unit]
     with StreamingServerTransport[Identity, Unit]:
 
   private val log = LoggerFactory.getLogger(classOf[ServerStdioTransport])
@@ -30,7 +37,7 @@ final class ServerStdioTransport(in: InputStream = System.in, out: OutputStream 
   def serve(server: StreamingMcpServer[Identity]): Unit =
     given MonadError[Identity] = IdentityMonad
     val handler = new McpHandler[Identity, StreamingServerContext[Identity]](server)
-    val reader = BufferedReader(InputStreamReader(in, StandardCharsets.UTF_8))
+    val reader = StdioLineReader(in, maxLineLength)
     val writer = BufferedWriter(OutputStreamWriter(out, StandardCharsets.UTF_8))
 
     def writeLine(json: io.circe.Json): Unit =
@@ -45,10 +52,9 @@ final class ServerStdioTransport(in: InputStream = System.in, out: OutputStream 
     val makeContext: Option[ProgressToken] => StreamingServerContext[Identity] =
       token => SinkStreamingServerContext(sink, token)
 
-    var line = reader.readLine()
-    while line != null do
-      if line.nonEmpty then
+    reader.lines
+      .filter(_.nonEmpty)
+      .foreach: line =>
         parser.parse(line) match
           case Right(json) => handler.handleJsonRpc(json, Nil, makeContext).body.foreach(writeLine)
           case Left(error) => log.warn(s"Failed to parse JSON-RPC line: ${error.getMessage}; raw: $line")
-      line = reader.readLine()

--- a/server/src/test/scala/chimp/server/ServerStdioTransportSpec.scala
+++ b/server/src/test/scala/chimp/server/ServerStdioTransportSpec.scala
@@ -4,9 +4,20 @@ import chimp.server.transport.ServerStdioTransport
 import sttp.shared.Identity
 
 import java.io.{InputStream, OutputStream}
+import scala.concurrent.{Future, Promise}
+import scala.util.Try
 
 class ServerStdioTransportSpec extends ServerStdioTransportTests[Identity] with SyncToFuture:
-  override protected def runStdioServer(server: StreamingMcpServer[Identity], in: InputStream, out: OutputStream): Unit =
-    val thread = Thread(() => ServerStdioTransport(in, out).serve(server))
+  override protected def runStdioServer(
+      server: StreamingMcpServer[Identity],
+      in: InputStream,
+      out: OutputStream,
+      maxLineLength: Int
+  ): Future[Unit] =
+    val served = Promise[Unit]()
+    val thread = Thread { () =>
+      val _ = served.complete(Try(ServerStdioTransport(in, out, maxLineLength).serve(server)))
+    }
     thread.setDaemon(true)
     thread.start()
+    served.future

--- a/server/src/test/scala/chimp/server/ServerStdioTransportTests.scala
+++ b/server/src/test/scala/chimp/server/ServerStdioTransportTests.scala
@@ -1,6 +1,7 @@
 package chimp.server
 
 import chimp.protocol.{JSONRPCErrorCodes, LoggingLevel}
+import chimp.transport.{McpLineTooLongException, StdioFraming}
 import io.circe.{parser, Codec, Json}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -18,11 +19,13 @@ import java.io.{
   PipedOutputStream
 }
 import java.nio.charset.StandardCharsets
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
 
 trait ServerStdioTransportTests[F[_]] extends AnyFlatSpec with Matchers:
   this: ToFuture[F] =>
 
-  protected def runStdioServer(server: StreamingMcpServer[F], in: InputStream, out: OutputStream): Unit
+  protected def runStdioServer(server: StreamingMcpServer[F], in: InputStream, out: OutputStream, maxLineLength: Int): Future[Unit]
 
   private case class EchoInput(message: String) derives Codec, Schema
   private case class NoInput() derives Codec, Schema
@@ -43,56 +46,82 @@ trait ServerStdioTransportTests[F[_]] extends AnyFlatSpec with Matchers:
           }
       )
 
-  private def withStdioServer[A](body: (String => Unit, () => Json) => A): A =
-    val toServer = PipedOutputStream()
-    val serverIn = PipedInputStream(toServer)
-    val fromServer = PipedInputStream()
-    val serverOut = PipedOutputStream(fromServer)
-
-    runStdioServer(server, serverIn, serverOut)
-
-    val writer = BufferedWriter(OutputStreamWriter(toServer, StandardCharsets.UTF_8))
-    val reader = BufferedReader(InputStreamReader(fromServer, StandardCharsets.UTF_8))
+  protected class StdioSession(toServer: PipedOutputStream, fromServer: PipedInputStream, val served: Future[Unit]):
+    private val writer = BufferedWriter(OutputStreamWriter(toServer, StandardCharsets.UTF_8))
+    private val reader = BufferedReader(InputStreamReader(fromServer, StandardCharsets.UTF_8))
 
     def send(line: String): Unit =
-      writer.write(line)
+      sendWithoutNewline(line)
       writer.newLine()
       writer.flush()
 
+    def sendWithoutNewline(line: String): Unit =
+      writer.write(line)
+      writer.flush()
+
+    def closeInput(): Unit = writer.close()
+
     def readResponse(): Json = parser.parse(reader.readLine()).toOption.get
 
-    try body(send, readResponse)
-    finally writer.close()
+  private def withStdioServer[A](maxLineLength: Int = StdioFraming.defaultMaxLineLength)(body: StdioSession => A): A =
+    val toServer = PipedOutputStream()
+    val serverIn = PipedInputStream(toServer, 64 * 1024)
+    val fromServer = PipedInputStream()
+    val serverOut = PipedOutputStream(fromServer)
 
-  "a stdio server" should "answer requests and stream notifications over stdin/stdout" in withStdioServer { (send, readResponse) =>
-    send(
+    val session = StdioSession(toServer, fromServer, runStdioServer(server, serverIn, serverOut, maxLineLength))
+
+    try body(session)
+    finally session.closeInput()
+
+  "a stdio server" should "answer requests and stream notifications over stdin/stdout" in withStdioServer() { session =>
+    session.send(
       """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}"""
     )
-    val init = readResponse()
+    val init = session.readResponse()
     init.hcursor.downField("id").as[Int] shouldBe Right(1)
     init.hcursor.downField("result").downField("serverInfo").downField("name").as[String].isRight shouldBe true
 
-    send("""{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hi"}}}""")
-    val echo = readResponse()
+    session.send("""{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hi"}}}""")
+    val echo = session.readResponse()
     echo.hcursor.downField("result").downField("content").downN(0).downField("text").as[String] shouldBe Right("hi")
 
-    send("""{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"noisy","arguments":{}}}""")
-    val notifications = List(readResponse(), readResponse(), readResponse())
+    session.send("""{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"noisy","arguments":{}}}""")
+    val notifications = List(session.readResponse(), session.readResponse(), session.readResponse())
     notifications.map(_.hcursor.downField("method").as[String]) shouldBe List.fill(3)(Right("notifications/message"))
     notifications.flatMap(_.hcursor.downField("params").downField("data").as[String].toOption) shouldBe List("one", "two", "three")
 
-    val response = readResponse()
+    val response = session.readResponse()
     response.hcursor.downField("id").as[Int] shouldBe Right(3)
     response.hcursor.downField("result").downField("content").downN(0).downField("text").as[String] shouldBe Right("done")
   }
 
-  it should "skip notifications and malformed lines, and still report protocol errors" in withStdioServer { (send, readResponse) =>
-    send("""{"jsonrpc":"2.0","method":"notifications/initialized"}""")
-    send("this is not valid json")
-    send("""{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"missing","arguments":{}}}""")
+  it should "skip notifications and malformed lines, and still report protocol errors" in withStdioServer() { session =>
+    session.send("""{"jsonrpc":"2.0","method":"notifications/initialized"}""")
+    session.send("this is not valid json")
+    session.send("""{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"missing","arguments":{}}}""")
 
-    val error = readResponse()
+    val error = session.readResponse()
     error.hcursor.downField("id").as[Int] shouldBe Right(9)
     error.hcursor.downField("error").downField("code").as[Int] shouldBe Right(JSONRPCErrorCodes.MethodNotFound.code)
     error.hcursor.downField("error").downField("message").as[String].toOption.get should include("missing")
+  }
+
+  it should "answer a request which is not terminated by a newline" in withStdioServer() { session =>
+    session.sendWithoutNewline("""{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"echo","arguments":{"message":"last"}}}""")
+    session.closeInput()
+
+    val echo = session.readResponse()
+    echo.hcursor.downField("id").as[Int] shouldBe Right(4)
+    echo.hcursor.downField("result").downField("content").downN(0).downField("text").as[String] shouldBe Right("last")
+
+    Await.result(session.served, 10.seconds)
+  }
+
+  it should "fail when an incoming line is longer than the maximum length" in withStdioServer(maxLineLength = 1024) { session =>
+    val padding = "x" * 8192
+    session.send(s"""{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"echo","arguments":{"message":"$padding"}}}""")
+
+    val failure = intercept[McpLineTooLongException](Await.result(session.served, 10.seconds))
+    failure.maxLineLength shouldBe 1024
   }


### PR DESCRIPTION
Max 10MB default, document the limits and server config options (tapir or interpreter specific).