### PR TITLE
feat: answer server/discover for connection-less capability discovery

### DIFF
--- a/docs/server/capabilities.md
+++ b/docs/server/capabilities.md
@@ -29,3 +29,7 @@ val server = StreamingMcpServer[Identity]().addStreamingTool(work)
 ```
 
 Server-wide capabilities are enabled by registering a handler — only what you wire up is advertised: `.withCompletion`, `.withLoggingLevel`, `.withSubscriptions`.
+
+## Discovery
+
+The chimp server is stateless: every request is handled on its own, no session is stored, and no `initialize` handshake is required before other methods. A client (or a proxy) can learn the server's capabilities up front with a `server/discover` request, which returns the same `serverInfo`, `capabilities` and `protocolVersion` as `initialize`, without negotiating a session.

--- a/server/src/main/scala/chimp/server/McpHandler.scala
+++ b/server/src/main/scala/chimp/server/McpHandler.scala
@@ -76,6 +76,8 @@ private[server] class McpHandler[F[_], C <: ServerContext[F]](server: McpServerD
         method match
           case "initialize" =>
             jsonResponse(handleInitialize(params, id)).unit
+          case "server/discover" =>
+            jsonResponse(JSONRPCMessage.Response(id = id, result = discoveryResult(ProtocolVersion.Latest).asJson)).unit
           case "ping" =>
             jsonResponse(JSONRPCMessage.Response(id = id, result = Json.obj())).unit
           case "tools/list" =>
@@ -117,24 +119,27 @@ private[server] class McpHandler[F[_], C <: ServerContext[F]](server: McpServerD
 
   private def jsonResponse(message: JSONRPCMessage): McpResponse = McpResponse.JsonResponse(message.asJson)
 
-  private def handleInitialize(params: Option[Json], id: RequestId): JSONRPCMessage.Response =
-    val requested = params.flatMap(_.hcursor.downField("protocolVersion").as[String].toOption)
-    val negotiated = requested.map(ProtocolVersion.negotiate).getOrElse(ProtocolVersion.Latest)
-    val capabilities = ServerCapabilities(
-      logging = Option.when(server.loggingLevel.isDefined)(Json.obj()),
-      completions = Option.when(server.completion.isDefined)(Json.obj()),
-      prompts = Option.when(server.prompts.nonEmpty)(ServerPromptsCapability(listChanged = Some(false))),
-      resources =
-        Option.when(hasResources)(ServerResourcesCapability(subscribe = Some(server.subscriptions.isDefined), listChanged = Some(false))),
-      tools = Option.when(server.tools.nonEmpty)(ServerToolsCapability(listChanged = Some(false)))
-    )
-    val result = InitializeResult(
-      protocolVersion = negotiated.name,
-      capabilities = capabilities,
+  private def serverCapabilities: ServerCapabilities = ServerCapabilities(
+    logging = Option.when(server.loggingLevel.isDefined)(Json.obj()),
+    completions = Option.when(server.completion.isDefined)(Json.obj()),
+    prompts = Option.when(server.prompts.nonEmpty)(ServerPromptsCapability(listChanged = Some(false))),
+    resources =
+      Option.when(hasResources)(ServerResourcesCapability(subscribe = Some(server.subscriptions.isDefined), listChanged = Some(false))),
+    tools = Option.when(server.tools.nonEmpty)(ServerToolsCapability(listChanged = Some(false)))
+  )
+
+  private def discoveryResult(protocolVersion: ProtocolVersion): InitializeResult =
+    InitializeResult(
+      protocolVersion = protocolVersion.name,
+      capabilities = serverCapabilities,
       serverInfo = Implementation(server.name, server.version),
       instructions = server.instructions
     )
-    JSONRPCMessage.Response(id = id, result = result.asJson)
+
+  private def handleInitialize(params: Option[Json], id: RequestId): JSONRPCMessage.Response =
+    val requested = params.flatMap(_.hcursor.downField("protocolVersion").as[String].toOption)
+    val negotiated = requested.map(ProtocolVersion.negotiate).getOrElse(ProtocolVersion.Latest)
+    JSONRPCMessage.Response(id = id, result = discoveryResult(negotiated).asJson)
 
   private def handleToolsCall(params: Option[Json], id: RequestId, headers: Seq[Header], makeContext: Option[ProgressToken] => C)(using
       MonadError[F]

--- a/server/src/test/scala/chimp/server/McpHandlerSpec.scala
+++ b/server/src/test/scala/chimp/server/McpHandlerSpec.scala
@@ -103,6 +103,19 @@ class McpHandlerSpec extends AnyFlatSpec with Matchers:
     // nulls should be dropped
     respJson.hcursor.downField("result").downField("instructions").focus shouldBe None
 
+  it should "respond to server/discover without an initialize handshake" in:
+    val req: JSONRPCMessage = Request(method = "server/discover", id = RequestId("disc"))
+    val response = handler.handleJsonRpc(req.asJson, Seq.empty)
+    val respJson = extractJsonFromResponse(response)
+
+    respJson.as[JSONRPCMessage].getOrElse(fail("Failed to decode response")) match
+      case Response(_, _, result) =>
+        val resultObj = result.as[InitializeResult].getOrElse(fail("Failed to decode result"))
+        resultObj.protocolVersion shouldBe ProtocolVersion.Latest.name
+        resultObj.capabilities.tools.isDefined shouldBe true
+        resultObj.serverInfo.name should include("Chimp MCP server")
+      case _ => fail("Expected Response")
+
   it should "list available tools" in:
     val req: JSONRPCMessage = Request(method = "tools/list", id = RequestId("2"))
     val json = req.asJson


### PR DESCRIPTION
Part of the [MCP roadmap](https://blog.modelcontextprotocol.io/posts/mcp-roadmap/)'s HTTP-native / stateless direction. Relates to #163.

## Context

chimp's server is **already stateless**: `McpHandler` handles each JSON-RPC request on its own, stores no session, issues no `Mcp-Session-Id`, and doesn't require an `initialize` handshake before other methods. So the 2026-07-28 "stateless architecture" is largely chimp's existing model — a request can land on any instance behind a plain round-robin load balancer.

The one concrete primitive it was missing is the discovery entry point.

## What

Handle the `server/discover` method: a client or proxy can learn the server's capabilities up front, without negotiating a session, before doing any real work. It returns the same `serverInfo`, `capabilities` and `protocolVersion` payload as `initialize` (the initialize capability computation is refactored into a shared `discoveryResult` helper, so the two can't drift).

Additive — an extra method the server answers — so it doesn't affect the `2025-11-25` conformance suite or existing clients.

## Tests

- `McpHandlerSpec` gets a case asserting `server/discover` returns the server info + capabilities with no prior `initialize`.
- `sbt scalafmtCheckAll compile Test/compile compileDocs` and the full `McpHandlerSpec` (33 cases) pass locally.

## Notes

The exact `server/discover` result shape in the 2026-07-28 RC isn't fully pinned down publicly yet; mirroring the `initialize` result (capabilities + serverInfo + protocolVersion + instructions) is the natural, forward-compatible choice. Happy to adjust to the final schema. Documented under server capabilities. Draft/WIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)